### PR TITLE
Node binary does not support Runtime Upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "kate",
+ "log",
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec 3.4.0",
@@ -1587,8 +1588,8 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.4.4"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+version = "0.4.5"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -1747,6 +1748,7 @@ dependencies = [
  "jsonrpsee",
  "kate",
  "kate-rpc",
+ "kate-rpc-runtime-api",
  "log",
  "lru 0.7.8",
  "mmr-rpc",
@@ -3868,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "kate"
 version = "0.7.0"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "da-primitives",
  "derive_more",
@@ -3895,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.8.0"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk",
@@ -3915,25 +3917,20 @@ version = "0.2.0"
 dependencies = [
  "avail-base",
  "da-primitives",
+ "da-runtime",
  "frame-support",
  "frame-system",
- "frame-system-rpc-runtime-api",
  "jsonrpsee",
  "kate",
  "kate-recovery",
  "kate-rpc-runtime-api",
  "lru 0.7.8",
  "parity-scale-codec 3.4.0",
- "rs_merkle",
  "sc-client-api",
  "sc-client-db",
  "sp-api",
  "sp-blockchain",
- "sp-core",
- "sp-rpc",
  "sp-runtime",
- "sp-std 5.0.0",
- "thiserror",
 ]
 
 [[package]]
@@ -5074,7 +5071,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.3"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -5093,7 +5090,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.3"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -5140,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "nomad-merkle"
 version = "0.1.1"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -5161,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "nomad-signature"
 version = "0.1.1"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.4#3de909c9bbe5926b282f597959e806dbff684d48"
+source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.5#eea185bf562fb24797f3fe5ba48481486da40854"
 dependencies = [
  "elliptic-curve",
  "ethers-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ frame-system-rpc-runtime-api = { path = "pallets/system/rpc/runtime-api" }
 frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 
 # Polygon Primitives
-da-primitives = { version = "0.4", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" } 
-kate = { version = "0.7", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
-kate-recovery = { version = "0.8", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
+da-primitives = { version = "0.4", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
+kate = { version = "0.7", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
+kate-recovery = { version = "0.8", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
 
 # Nomad
-nomad-signature = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
-nomad-merkle = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
-nomad-base = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
-nomad-core = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.4" }
+nomad-signature = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
+nomad-merkle = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
+nomad-base = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
+nomad-core = { version = "0.1", git="https://github.com/maticnetwork/avail-core", tag = "da-primitives/v0.4.5" }
 
 # Other stuff
 uint = { git = "https://github.com/paritytech/parity-common.git", tag="rlp-v0.5.2" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,8 @@ name = "data-avail"
 
 [dependencies]
 avail-base = { path = "../base" }
+kate-rpc-runtime-api = { path = "../rpc/kate-rpc-runtime-api" }
+
 # Internals
 da-primitives = { version = "0.4", default-features = false }
 kate = { version = "0.7", default-features = false }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -204,8 +204,7 @@ where
 
 	io.merge(StateMigration::new(client.clone(), backend, deny_unsafe).into_rpc())?;
 
-	let kate = Kate::<C, Block>::new(client);
-	io.merge(kate.into_rpc())?;
+	io.merge(Kate::<C, Block>::new(client).into_rpc())?;
 
 	Ok(io)
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,17 +28,17 @@
 //! are part of it. Therefore all node-runtime-specific RPCs can
 //! be placed here or imported from corresponding FRAME RPC definitions.
 
-//! # Polygon Changes
+//! # Data Availability Changes
 //! - Add Kate RPC extension.
-//! - Remove Contrats extensions.
+//! - Remove `sc_rpc::dev` extension.
 
 #![warn(missing_docs)]
 
 use std::sync::Arc;
 
-use da_runtime::{Block, BlockNumber, Hash, Runtime};
+use da_runtime::{AccountId, Balance, BlockNumber, Hash, Index, NodeBlock as Block};
 use jsonrpsee::RpcModule;
-use sc_client_api::BlockBackend;
+use sc_client_api::AuxStore;
 use sc_consensus_babe::{BabeConfiguration, Epoch};
 use sc_consensus_epochs::SharedEpochChanges;
 use sc_finality_grandpa::{
@@ -46,9 +46,13 @@ use sc_finality_grandpa::{
 };
 use sc_rpc::SubscriptionTaskExecutor;
 pub use sc_rpc_api::DenyUnsafe;
+use sc_transaction_pool_api::TransactionPool;
+use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_consensus::SelectChain;
+use sp_consensus_babe::BabeApi;
 use sp_keystore::SyncCryptoStorePtr;
-
-use crate::service::{FullBackend, FullClient, TransactionPool};
 
 /// Extra dependencies for BABE.
 pub struct BabeDeps {
@@ -61,7 +65,7 @@ pub struct BabeDeps {
 }
 
 /// Extra dependencies for GRANDPA
-pub struct GrandpaDeps {
+pub struct GrandpaDeps<B> {
 	/// Voting round info.
 	pub shared_voter_state: SharedVoterState,
 	/// Authority set info.
@@ -71,17 +75,17 @@ pub struct GrandpaDeps {
 	/// Executor to drive the subscription manager in the Grandpa RPC handler.
 	pub subscription_executor: SubscriptionTaskExecutor,
 	/// Finality proof provider.
-	pub finality_provider: Arc<FinalityProofProvider<FullBackend, Block>>,
+	pub finality_provider: Arc<FinalityProofProvider<B, Block>>,
 }
 
 /// Full client dependencies.
-pub struct FullDeps {
+pub struct FullDeps<C, P, SC, B> {
 	/// The client instance to use.
-	pub client: Arc<FullClient>,
+	pub client: Arc<C>,
 	/// Transaction pool instance.
-	pub pool: Arc<TransactionPool>,
+	pub pool: Arc<P>,
 	/// The SelectChain Strategy
-	pub select_chain: sc_consensus::LongestChain<FullBackend, Block>,
+	pub select_chain: SC,
 	/// A copy of the chain spec.
 	pub chain_spec: Box<dyn sc_chain_spec::ChainSpec>,
 	/// Whether to deny unsafe calls
@@ -89,20 +93,39 @@ pub struct FullDeps {
 	/// BABE specific dependencies.
 	pub babe: BabeDeps,
 	/// GRANDPA specific dependencies.
-	pub grandpa: GrandpaDeps,
+	pub grandpa: GrandpaDeps<B>,
 }
 
 /// Instantiate all Full RPC extensions.
-pub fn create_full(
-	deps: FullDeps,
-	backend: Arc<FullBackend>,
-) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>> {
+pub fn create_full<C, P, SC, B>(
+	deps: FullDeps<C, P, SC, B>,
+	backend: Arc<B>,
+) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
+where
+	C: ProvideRuntimeApi<Block>
+		+ sc_client_api::BlockBackend<Block>
+		+ HeaderBackend<Block>
+		+ AuxStore
+		+ HeaderMetadata<Block, Error = BlockChainError>
+		+ Sync
+		+ Send
+		+ 'static,
+	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: mmr_rpc::MmrRuntimeApi<Block, <Block as sp_runtime::traits::Block>::Hash, BlockNumber>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: BabeApi<Block>,
+	C::Api: BlockBuilder<Block>,
+	C::Api: kate_rpc_runtime_api::KateParamsGetter<Block>,
+	P: TransactionPool + 'static,
+	SC: SelectChain<Block> + 'static,
+	B: sc_client_api::Backend<Block> + Send + Sync + 'static,
+	B::State: sc_client_api::backend::StateBackend<sp_runtime::traits::HashFor<Block>>,
+{
 	use kate_rpc::{Kate, KateApiServer};
 	use mmr_rpc::{Mmr, MmrApiServer};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use sc_consensus_babe_rpc::{Babe, BabeApiServer};
 	use sc_finality_grandpa_rpc::{Grandpa, GrandpaApiServer};
-	// use sc_rpc::dev::{Dev, DevApiServer};
 	use sc_rpc_spec_v2::chain_spec::{ChainSpec, ChainSpecApiServer};
 	use sc_sync_state_rpc::{SyncState, SyncStateApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -180,9 +203,9 @@ pub fn create_full(
 	)?;
 
 	io.merge(StateMigration::new(client.clone(), backend, deny_unsafe).into_rpc())?;
-	// io.merge(Dev::new(client, deny_unsafe).into_rpc())?;
 
-	io.merge(Kate::<_, _, Runtime>::new(client).into_rpc())?;
+	let kate = Kate::<C, Block>::new(client);
+	io.merge(kate.into_rpc())?;
 
 	Ok(io)
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -349,7 +349,7 @@ pub fn new_full_base(
 ) -> Result<NewFullBase, ServiceError> {
 	let hwbench = if !disable_hardware_benchmarks {
 		config.database.path().map(|database_path| {
-			let _ = std::fs::create_dir_all(&database_path);
+			let _ = std::fs::create_dir_all(database_path);
 			sc_sysinfo::gather_hwbench(Some(database_path))
 		})
 	} else {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use codec::Encode;
 use da_primitives::asdr::AppId;
-use da_runtime::{Block, Runtime, RuntimeApi};
+use da_runtime::{NodeBlock as Block, Runtime, RuntimeApi};
 use frame_system_rpc_runtime_api::AccountNonceApi;
 use futures::prelude::*;
 use pallet_transaction_payment::ChargeTransactionPayment;
@@ -196,7 +196,7 @@ pub fn new_partial(
 	);
 
 	let (client, backend, keystore_container, task_manager) =
-		sc_service::new_full_parts::<da_runtime::Block, RuntimeApi, _>(
+		sc_service::new_full_parts::<Block, RuntimeApi, _>(
 			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
@@ -349,7 +349,7 @@ pub fn new_full_base(
 ) -> Result<NewFullBase, ServiceError> {
 	let hwbench = if !disable_hardware_benchmarks {
 		config.database.path().map(|database_path| {
-			let _ = std::fs::create_dir_all(database_path);
+			let _ = std::fs::create_dir_all(&database_path);
 			sc_sysinfo::gather_hwbench(Some(database_path))
 		})
 	} else {

--- a/pallets/dactr/Cargo.toml
+++ b/pallets/dactr/Cargo.toml
@@ -15,6 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 da-primitives = { version = "0.4", default-features = false }
 kate = { version = "0.7", default-features = false }
 
+log = { version = "0.4.17", default-features = false }
+
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
@@ -36,6 +38,7 @@ test-case = "1.2.3"
 [features]
 default = ["std"]
 std = [
+	"log/std",
 	"da-primitives/std",
 	"serde",
 	"codec/std",

--- a/pallets/system/src/submitted_data.rs
+++ b/pallets/system/src/submitted_data.rs
@@ -29,6 +29,7 @@ pub trait Extractor {
 	fn extract(app_ext: AppExtrinsic, metrics: RcMetrics) -> Option<Vec<u8>>;
 }
 
+#[cfg(any(feature = "std", test))]
 impl Extractor for () {
 	fn extract(_: AppExtrinsic, _: RcMetrics) -> Option<Vec<u8>> { None }
 }
@@ -39,6 +40,7 @@ pub trait Filter<C> {
 	fn filter(call: C, metrics: RcMetrics) -> Option<Vec<u8>>;
 }
 
+#[cfg(any(feature = "std", test))]
 impl<C> Filter<C> for () {
 	fn filter(_: C, _: RcMetrics) -> Option<Vec<u8>> { None }
 }

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -6,27 +6,39 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-avail-base = { path = "../../base" }
-
-sp-api = { version = "4.0.0-dev", default-features = false }
-sp-std = { version = "5.0.0", default-features = false }
-frame-system = { version = "4.0.0-dev", default-features = false }
-frame-support = { version = "4.0.0-dev", default-features = false }
+avail-base = { path = "../../base", default-features = false }
 kate-rpc-runtime-api = { path = "../kate-rpc-runtime-api", default-features = false }
-sc-client-db = { version = "0.10.0-dev", default-features = false }
-thiserror = "1.0.30" 
-rs_merkle = { version = "1.2.0", default-features = false }
+da-runtime = { path = "../../runtime", default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3" }
 da-primitives = { version = "0.4", default-features = false }
 kate = { version = "0.7", default-features = false }
 kate-recovery = { version = "0.8", default-features = false }
-jsonrpsee = { version = "0.16.2", features = ["server", "client", "macros"] }
 
-frame-system-rpc-runtime-api = "4.0.0-dev"
+jsonrpsee = { version = "0.16.2", features = ["server", "client", "macros"] }
 lru = "0.7.2"
+
+# Substrate
+sp-api = { version = "4.0.0-dev", default-features = false }
+frame-system = { version = "4.0.0-dev", default-features = false }
+frame-support = { version = "4.0.0-dev", default-features = false }
+sc-client-db = "0.10.0-dev"
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 sc-client-api = "4.0.0-dev"
 sp-blockchain = "4.0.0-dev"
-sp-rpc = "6.0.0"
-sp-runtime = "7.0.0"
-sp-core = "7.0.0"
+sp-runtime = { version = "7.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"avail-base/std",
+	"da-runtime/std",
+	"kate-rpc-runtime-api/std",
+	"da-primitives/std",
+	"kate/std",
+	"kate-recovery/std",
+	"frame-support/std",
+	"frame-system/std",
+	"codec/std",
+	"sp-api/std",
+	"sp-runtime/std",
+]


### PR DESCRIPTION
Use `OpaqueExtrinsic` at node binary level. That makes the binary completely agnostic to the underlying runtime.

## Companion PRs
- [Avail-Core#28](https://github.com/availproject/avail-core/pull/28)
- [Avail-apps#23](https://github.com/availproject/avail-apps/pull/23)

## Side-Effects
- RPC interfaces need to transform from `OpaqueExtrinsic` into `AppUncheckedExtrinsic` manually, like https://github.com/availproject/avail/blob/381e1539e0829b4c3d6551437c88fc9af32ebd22/rpc/kate-rpc/src/lib.rs#L164