### PR TITLE
Update nomad updater address.

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -324,7 +324,7 @@ pub fn testnet_genesis(
 			],
 		},
 		updater_manager: UpdaterManagerConfig {
-			updater: "0x1563915e194d8cfba1943570603f7606a3115508"
+			updater: "0x7eB31daE170c1Cb25A7257524e98273e89F32DdC"
 				.parse()
 				.unwrap(),
 			_phantom: Default::default(),
@@ -332,7 +332,7 @@ pub fn testnet_genesis(
 		nomad_home: NomadHomeConfig {
 			local_domain: 2000,
 			committed_root: Default::default(),
-			updater: "0x1563915e194d8cfba1943570603f7606a3115508"
+			updater: "0x7eB31daE170c1Cb25A7257524e98273e89F32DdC"
 				.parse()
 				.unwrap(),
 			_phantom: Default::default(),


### PR DESCRIPTION
Change chain spec to update nomad updater address for devnet. 
This is related to the configuration file: https://github.com/availproject/nomad-config/pull/1/files#diff-98da95bd9dbd4979eaef5e00a61c00e5bb41f0342443a250923582923fadca48R151 