### PR TITLE
Enable public access to inner tuple for Grandpa and BABE AccountId.

### DIFF
--- a/avail-subxt/src/primitives/babe.rs
+++ b/avail-subxt/src/primitives/babe.rs
@@ -5,7 +5,7 @@ use serde_hex::{SerHex, StrictPfx};
 use crate::api::runtime_types::{sp_consensus_babe::app::Public, sp_core::sr25519::Signature};
 
 #[derive(Decode)]
-pub struct AuthorityId(Public);
+pub struct AuthorityId(pub Public);
 
 impl Serialize for AuthorityId {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -18,7 +18,7 @@ impl Serialize for AuthorityId {
 }
 
 #[derive(Decode)]
-pub struct AuthoritySignature(Signature);
+pub struct AuthoritySignature(pub Signature);
 
 impl Serialize for AuthoritySignature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/avail-subxt/src/primitives/grandpa.rs
+++ b/avail-subxt/src/primitives/grandpa.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Serializer};
 use crate::api::runtime_types::sp_finality_grandpa::app::Public;
 
 #[derive(Decode)]
-pub struct AuthorityId(Public);
+pub struct AuthorityId(pub Public);
 
 impl Serialize for AuthorityId {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
We need this for verification purposes, access outside the crate is private by default. We could perhaps also implement from/into, but this is easier (?)