### PR TITLE
Fix the `set_code`'s weights

### DIFF
--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 		/// expensive. We will treat this as a full block.
 		/// # </weight>
 		#[pallet::call_index(2)]
-		#[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
+		#[pallet::weight(weights::set_code::<T>())]
 		pub fn set_code(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			Self::can_set_code(&code)?;
@@ -463,7 +463,7 @@ pub mod pallet {
 		/// The weight of this function is dependent on the runtime. We will treat this as a full
 		/// block. # </weight>
 		#[pallet::call_index(3)]
-		#[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
+		#[pallet::weight(weights::set_code::<T>())]
 		pub fn set_code_without_checks(
 			origin: OriginFor<T>,
 			code: Vec<u8>,
@@ -1866,4 +1866,22 @@ pub mod pallet_prelude {
 
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
+}
+
+mod weigths {
+	use super::*;
+
+	/// Weight for `system::set_code`.
+	///
+	/// It fills the whole block in terms of weight.
+	fn set_code<T: Config>() -> (Weight, DispatchClass) {
+		let class = DispatchClass::Operational;
+		let block_weights = T::BlockWeights::get();
+		let max = block_weights
+			.get(class)
+			.max_extrinsic
+			.unwrap_or(block_weights.max_block);
+
+		(max, class)
+	}
 }

--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 		/// expensive. We will treat this as a full block.
 		/// # </weight>
 		#[pallet::call_index(2)]
-		#[pallet::weight(weights::set_code::<T>())]
+		#[pallet::weight(weight_helper::set_code::<T>())]
 		pub fn set_code(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			Self::can_set_code(&code)?;
@@ -463,7 +463,7 @@ pub mod pallet {
 		/// The weight of this function is dependent on the runtime. We will treat this as a full
 		/// block. # </weight>
 		#[pallet::call_index(3)]
-		#[pallet::weight(weights::set_code::<T>())]
+		#[pallet::weight(weight_helper::set_code::<T>())]
 		pub fn set_code_without_checks(
 			origin: OriginFor<T>,
 			code: Vec<u8>,
@@ -1868,13 +1868,13 @@ pub mod pallet_prelude {
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
 
-mod weigths {
+mod weight_helper {
 	use super::*;
 
 	/// Weight for `system::set_code`.
 	///
 	/// It fills the whole block in terms of weight.
-	fn set_code<T: Config>() -> (Weight, DispatchClass) {
+	pub(crate) fn set_code<T: Config>() -> (Weight, DispatchClass) {
 		let class = DispatchClass::Operational;
 		let block_weights = T::BlockWeights::get();
 		let max = block_weights

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -100,7 +100,9 @@ pub mod time {
 
 pub mod system {
 	use da_primitives::NORMAL_DISPATCH_RATIO;
-	use frame_support::weights::constants::{ExtrinsicBaseWeight, WEIGHT_REF_TIME_PER_SECOND};
+	use frame_support::weights::constants::{
+		ExtrinsicBaseWeight, WEIGHT_REF_TIME_PER_MILLIS, WEIGHT_REF_TIME_PER_SECOND,
+	};
 	use frame_system::limits::BlockWeights as SystemBlockWeights;
 
 	use super::*;
@@ -112,10 +114,21 @@ pub mod system {
 	/// We assume that ~10% of the block weight is consumed by `on_initialize` handlers.
 	/// This is used to limit the maximal weight of a single extrinsic.
 	const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
+
+	/// Proof size allowed up to 500ms.
+	const MAX_POV_SIZE: u64 = WEIGHT_REF_TIME_PER_MILLIS.saturating_mul(500);
+
 	/// We allow for 2 seconds of compute with a 6 second average block time, with maximum proof size.
+	#[cfg(feature = "fast-runtime")]
 	const MAXIMUM_BLOCK_WEIGHT: Weight =
 		Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2))
-			.set_proof_size(u64::MAX);
+			.set_proof_size(MAX_POV_SIZE);
+
+	/// We allow for 5 seconds of compute with a 20 second average block time, with maximum proof size.
+	#[cfg(not(feature = "fast-runtime"))]
+	const MAXIMUM_BLOCK_WEIGHT: Weight =
+		Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(5))
+			.set_proof_size(MAX_POV_SIZE);
 
 	parameter_types! {
 	pub RuntimeBlockWeights: SystemBlockWeights = SystemBlockWeights::builder()


### PR DESCRIPTION
It fixes the `system::set_code(..)`'s weights, using `max_extrinsic` weight instead of `max_block`.

It also changes 2 things (att @prabal-banerjee ):
- Max Ref Weight for a block has been increased from 2 secs to 5 secs (only in non `fast-runtime`)
- Max Proof Size has been reduced from `u64:MAX` to `500ms`, which we could use in the future to handle `data-root` & `kate-commitment` built.
