### PR TITLE
Remove unnecessary debug logs.

### DIFF
--- a/pallets/system/src/submitted_data.rs
+++ b/pallets/system/src/submitted_data.rs
@@ -207,13 +207,6 @@ fn proof(
 		metrics
 	);
 
-	// let leaf = str::from_utf8(proof.leaf.as_slice()).unwrap(); //str::from_utf8(proof.leaf.as_slice()).unwrap();
-	log::debug!("Leaf generated size: {}", proof.leaf.len());
-
-	for l in &proof.leaf {
-		log::debug!(target: LOG_TARGET, "Leaf generated {}", l);
-	}
-
 	Some(proof)
 }
 


### PR DESCRIPTION
Remove unnecessary logs when building a proof.