### PR TITLE
Switch to decoding extrinsics inside runtime instead of kate RPC to a…

### DIFF
--- a/pallets/bridges/nomad/da-bridge/src/mock.rs
+++ b/pallets/bridges/nomad/da-bridge/src/mock.rs
@@ -62,6 +62,7 @@ impl system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/bridges/nomad/home/src/mock.rs
+++ b/pallets/bridges/nomad/home/src/mock.rs
@@ -62,6 +62,7 @@ impl system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/bridges/nomad/updater-manager/src/mock.rs
+++ b/pallets/bridges/nomad/updater-manager/src/mock.rs
@@ -53,6 +53,7 @@ impl system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/dactr/src/mock.rs
+++ b/pallets/dactr/src/mock.rs
@@ -73,6 +73,7 @@ impl frame_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/mocked_runtime/src/lib.rs
+++ b/pallets/mocked_runtime/src/lib.rs
@@ -155,6 +155,7 @@ impl frame_system::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
 	type SubmittedDataExtractor = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SystemWeightInfo = ();
 	type Version = RuntimeVersion;
 }

--- a/pallets/system/benches/bench.rs
+++ b/pallets/system/benches/bench.rs
@@ -102,6 +102,7 @@ impl frame_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/system/benchmarking/src/mock.rs
+++ b/pallets/system/benchmarking/src/mock.rs
@@ -70,6 +70,7 @@ impl frame_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -387,6 +387,7 @@ pub mod pallet {
 		/// Filter used by `DataRootBuilder`.
 		type SubmittedDataExtractor: submitted_data::Extractor
 			+ submitted_data::Filter<Self::RuntimeCall>;
+
 		/// Extractor of AppId.
 		type SubmittedDataAppIdExtractor: submitted_data::AppIdExtractor
 			+ submitted_data::Filter<Self::RuntimeCall>;

--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -387,6 +387,9 @@ pub mod pallet {
 		/// Filter used by `DataRootBuilder`.
 		type SubmittedDataExtractor: submitted_data::Extractor
 			+ submitted_data::Filter<Self::RuntimeCall>;
+		/// Extractor of AppId.
+		type SubmittedDataAppIdExtractor: submitted_data::AppIdExtractor
+			+ submitted_data::Filter<Self::RuntimeCall>;
 
 		/// UncheckedExtrinsic Type used on Kate commitment & Data root calculation.
 		type UncheckedExtrinsic: Into<AppExtrinsic>

--- a/pallets/system/src/mock.rs
+++ b/pallets/system/src/mock.rs
@@ -111,6 +111,7 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type SS58Prefix = ();
+	type SubmittedDataAppIdExtractor = ();
 	type SubmittedDataExtractor = ();
 	type SystemWeightInfo = ();
 	type UncheckedExtrinsic = UncheckedExtrinsic;

--- a/pallets/system/src/submitted_data.rs
+++ b/pallets/system/src/submitted_data.rs
@@ -90,7 +90,7 @@ where
 }
 
 /// Extracts just the AppId from the extrinsic (if it is signed), otherwise returns None.
-fn extract_app_id_and_inspect<AE>(opaque: &OpaqueExtrinsic) -> Option<AppId>
+pub fn extract_app_id<AE>(opaque: &OpaqueExtrinsic) -> Option<AppId>
 where
 	AE: AppIdExtractor,
 	AE::Error: Debug,
@@ -197,17 +197,6 @@ where
 		.collect::<Vec<_>>();
 
 	proof(submitted_data, data_index, Rc::clone(&metrics))
-}
-
-/// Extracts the AppId from extrinsic, if it is signed, returns None otherwise.
-pub fn extract_app_id<AE>(extrinsic: &OpaqueExtrinsic) -> Option<AppId>
-where
-	AE: AppIdExtractor,
-	AE::Error: Debug,
-{
-	let app_id = extract_app_id_and_inspect::<AE>(extrinsic);
-
-	app_id
 }
 
 /// Creates the Merkle Proof of the submitted data items in `calls` filtered by `F` and

--- a/pallets/system/src/submitted_data.rs
+++ b/pallets/system/src/submitted_data.rs
@@ -43,16 +43,14 @@ pub trait Extractor {
 pub trait AppIdExtractor {
 	type Error: Debug;
 	/// Returns the `AppId` field of `encoded_extrinsic` if it is a signed extrinsic.
-	///
-	/// The `metrics` will be used to write accountability information about the whole process.
-	fn extract(extrinsic: &OpaqueExtrinsic, metrics: RcMetrics) -> Result<AppId, Self::Error>;
+	fn extract(extrinsic: &OpaqueExtrinsic) -> Result<AppId, Self::Error>;
 }
 
 #[cfg(any(feature = "std", test))]
 impl AppIdExtractor for () {
 	type Error = ();
 
-	fn extract(_: &OpaqueExtrinsic, _: RcMetrics) -> Result<AppId, ()> { Ok(AppId(0)) }
+	fn extract(_: &OpaqueExtrinsic) -> Result<AppId, ()> { Ok(AppId(0)) }
 }
 
 #[cfg(any(feature = "std", test))]
@@ -92,12 +90,12 @@ where
 }
 
 /// Extracts just the AppId from the extrinsic (if it is signed), otherwise returns None.
-fn extract_app_id_and_inspect<AE>(opaque: &OpaqueExtrinsic, metrics: RcMetrics) -> Option<AppId>
+fn extract_app_id_and_inspect<AE>(opaque: &OpaqueExtrinsic) -> Option<AppId>
 where
 	AE: AppIdExtractor,
 	AE::Error: Debug,
 {
-	let app_id = AE::extract(opaque, Rc::clone(&metrics))
+	let app_id = AE::extract(opaque)
 		.inspect_err(|e| log::error!("Extractor cannot extract AppId from opaque: {e:?}"))
 		.ok();
 
@@ -207,8 +205,7 @@ where
 	AE: AppIdExtractor,
 	AE::Error: Debug,
 {
-	let metrics = Metrics::new_shared();
-	let app_id = extract_app_id_and_inspect::<AE>(extrinsic, metrics);
+	let app_id = extract_app_id_and_inspect::<AE>(extrinsic);
 
 	app_id
 }

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -10,9 +10,7 @@ use avail_core::{
 	BlockLengthRows, DataProof, OpaqueExtrinsic, BLOCK_CHUNK_SIZE,
 };
 use codec::{Decode, Encode, Input};
-use da_runtime::{
-	apis::DataAvailApi, Address, Runtime, Signature, SignedExtra,
-};
+use da_runtime::{apis::DataAvailApi, Address, Runtime, Signature, SignedExtra};
 use frame_system::{
 	limits::BlockLength,
 	submitted_data::{self},
@@ -165,7 +163,9 @@ fn app_id_from_opaque(opaque: &OpaqueExtrinsic) -> Result<AppId, String> {
 		.transpose()
 		.map_err(|e| format!("{e:?}"))?;
 
-	signature.map(|(_address, _signature, extra)| extra.app_id()).ok_or("Not signed".to_string())
+	signature
+		.map(|(_address, _signature, extra)| extra.8 .0)
+		.ok_or("Not signed".to_string())
 }
 
 #[async_trait]

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -146,28 +146,6 @@ where
 	}
 }
 
-/// Unused function to demonstrate how to get only extract the app_id from an opaque extrinsic
-#[allow(dead_code)]
-fn app_id_from_opaque(opaque: &OpaqueExtrinsic) -> Result<AppId, String> {
-	let input = &mut opaque.0.as_slice();
-	let version = input.read_byte().unwrap();
-
-	let is_signed = version & 0b1000_0000 != 0;
-	let version = version & 0b0111_1111;
-	if version != 4 {
-		return Err("Invalid transaction version".to_string());
-	}
-
-	let signature: Option<(Address, Signature, SignedExtra)> = is_signed
-		.then(|| Decode::decode(input))
-		.transpose()
-		.map_err(|e| format!("{e:?}"))?;
-
-	signature
-		.map(|(_address, _signature, extra)| extra.8 .0)
-		.ok_or("Not signed".to_string())
-}
-
 #[async_trait]
 impl<Client, Block> KateApiServer<Block> for Kate<Client, Block>
 where

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -148,6 +148,8 @@ where
 	}
 }
 
+/// Unused function to demonstrate how to get only extract the app_id from an opaque extrinsic
+#[allow(dead_code)]
 fn app_id_from_opaque(opaque: &OpaqueExtrinsic) -> Result<AppId, String> {
 	let input = &mut opaque.0.as_slice();
 	let version = input.read_byte().unwrap();

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -165,7 +165,7 @@ fn app_id_from_opaque(opaque: &OpaqueExtrinsic) -> Result<AppId, String> {
 		.transpose()
 		.map_err(|e| format!("{e:?}"))?;
 
-	signature.map(|e| e.2 .8 .0).ok_or("Not signed".to_string())
+	signature.map(|(_address, _signature, extra)| extra.app_id()).ok_or("Not signed".to_string())
 }
 
 #[async_trait]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -221,10 +221,7 @@ impl submitted_data::Extractor for Runtime {
 impl submitted_data::AppIdExtractor for Runtime {
 	type Error = codec::Error;
 
-	fn extract(
-		opaque: &OpaqueExtrinsic,
-		metrics: submitted_data::RcMetrics,
-	) -> Result<AppId, Self::Error> {
+	fn extract(opaque: &OpaqueExtrinsic) -> Result<AppId, Self::Error> {
 		let extrinsic = UncheckedExtrinsic::try_from(opaque)?;
 		let appid = extrinsic.signature.map(|e| e.2 .8 .0).unwrap_or(AppId(0));
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -217,6 +217,21 @@ impl submitted_data::Extractor for Runtime {
 	}
 }
 
+/// Decodes and extracts the `AppId` of signed extrinsics.
+impl submitted_data::AppIdExtractor for Runtime {
+	type Error = codec::Error;
+
+	fn extract(
+		opaque: &OpaqueExtrinsic,
+		metrics: submitted_data::RcMetrics,
+	) -> Result<AppId, Self::Error> {
+		let extrinsic = UncheckedExtrinsic::try_from(opaque)?;
+		let appid = extrinsic.signature.map(|e| e.2 .8 .0).unwrap_or(AppId(0));
+
+		Ok(appid)
+	}
+}
+
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
 	/// The data to be stored in an account.
@@ -268,6 +283,8 @@ impl frame_system::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 	type SS58Prefix = constants::system::SS58Prefix;
+	/// AppId extractor
+	type SubmittedDataAppIdExtractor = Runtime;
 	/// Data Root
 	type SubmittedDataExtractor = Runtime;
 	/// Weight information for the extrinsics of this pallet.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,10 @@ impl submitted_data::AppIdExtractor for Runtime {
 
 	fn extract(opaque: &OpaqueExtrinsic) -> Result<AppId, Self::Error> {
 		let extrinsic = UncheckedExtrinsic::try_from(opaque)?;
-		let appid = extrinsic.signature.map(|(_a, _s, extra)| extra.app_id()).unwrap_or_default();
+		let appid = extrinsic
+			.signature
+			.map(|(_a, _s, extra)| extra.app_id())
+			.unwrap_or_default();
 
 		Ok(appid)
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,7 @@ impl submitted_data::AppIdExtractor for Runtime {
 
 	fn extract(opaque: &OpaqueExtrinsic) -> Result<AppId, Self::Error> {
 		let extrinsic = UncheckedExtrinsic::try_from(opaque)?;
-		let appid = extrinsic.signature.map(|e| e.2 .8 .0).unwrap_or(AppId(0));
+		let appid = extrinsic.signature.map(|(_a, _s, extra)| extra.app_id()).unwrap_or_default();
 
 		Ok(appid)
 	}


### PR DESCRIPTION
…void problems with runtime upgrades. Don't silently filter out extrinsics. Log issues.