### PR TITLE
chore: Added script for benchmarking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 fuzzing/testing/out
 tests/rust_scripts/target
 .vscode
+output

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ We also add `--tmp`, therefore the state will be deleted at the end of the proce
 
 ## Run benchmarks
 
+### Manually
 You can run any benchmark and generate the proper `weight.rs` file. In the following command, we are
 running the benchmarks from `da-control` pallet, and the generated file is 
 
@@ -84,6 +85,32 @@ running the benchmarks from `da-control` pallet, and the generated file is
         --extrinsic=* \
         --output=./pallets/dactr/src/weights.rs
 
+### Via Script
+To run all benchmarks from all pallets:
+```bash
+./run_benchmarks.sh
+```
+
+You can customize the number of steps and repeats for the benchmarks using
+environment variables. For example, to set the number of steps to 4 and the
+number of repeats to 20, use the following command:
+```bash
+STEPS=4 REPEAT=20 ./run_benchmarks.sh
+```
+
+If you only want to run benchmarks just for our own custom pallets, you can set the
+OUR_PALLETS environment variable:
+```bash
+OUR_PALLETS=1 ./run_benchmarks.sh
+```
+
+To run benchmarks for specific pallets, you need to set the PALLETS environment
+variable and provide a space-separated list of pallet names. For example, to run
+benchmarks for the frame_system and mocked_runtime pallets, use the following
+command:
+```bash
+PALLETS="frame_system mocked_runtime" ./run_benchmarks.sh
+```
 
 ## Transaction Custom IDs
 

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+STEPS="${STEPS:-50}"
+REPEAT="${REPEAT:-20}"
+TEMPLATE_PATH="${TEMPLATE_PATH:-./.maintain/frame-weight-template.hbs}"
+OUTPUT_PATH="${OUTPUT_PATH:-./output}"
+BINARY_LOCATION="./target/release/data-avail"
+PALLETS="${PALLETS:-*}"
+
+echo "STEPS: $STEPS, REPEAT: $REPEAT"
+echo "PALLETS: $PALLETS"
+echo "TEMPLATE_PATH: $TEMPLATE_PATH"
+echo "OUTPUT_PATH: $OUTPUT_PATH"
+echo "OUR_PALLETS: $OUR_PALLETS"
+echo "BINARY_LOCATION: $BINARY_LOCATION"
+
+run_benchmark() {
+    echo "Pallets: ${PALLETS[@]}"
+    
+    rm -f $ERR_FILE
+    mkdir -p "$OUTPUT_PATH"
+    
+    for PALLET in "${PALLETS[@]}"; do
+        if is_pallet_excluded; then
+            echo "[ ] Skipping pallet $PALLET"
+            continue
+        fi
+        
+        file_name="$PALLET.rs"
+        
+        benchmark "$template_arg" "$file_name"
+        
+        if is_custom_pallet; then
+            template_name="${PALLET}_weights.rs"
+            benchmark "--template $TEMPLATE_PATH" "$template_name"
+        fi
+        
+    done
+}
+
+benchmark() {
+    echo "[+] Benchmarking $PALLET"
+    
+    OUTPUT=$($BINARY_LOCATION benchmark pallet --chain=dev --steps=$STEPS --repeat=$REPEAT --pallet="$PALLET" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./HEADER-APACHE2 --log=warn --output "$OUTPUT_PATH/$2" $1 2>&1)
+    if [ $? -ne 0 ]; then
+        echo "$OUTPUT" >>"$ERR_FILE"
+        echo "[-] Failed to benchmark $PALLET. Error written to $ERR_FILE; continuing..."
+    fi
+}
+
+is_pallet_excluded() {
+    for EXCLUDED_PALLET in "${EXCLUDED_PALLETS[@]}"; do
+        if [ "$EXCLUDED_PALLET" == "$PALLET" ]; then
+            return 0
+        fi
+    done
+    
+    return 1
+}
+
+is_custom_pallet() {
+    for CUSTOM_PALLETS in "${CUSTOM_PALLETS[@]}"; do
+        if [ "$CUSTOM_PALLETS" == "$PALLET" ]; then
+            return 0
+        fi
+    done
+    
+    return 1
+}
+
+populate_pallet_list() {
+    # Manually exclude some pallets.
+    EXCLUDED_PALLETS=(
+        # Helper pallets
+        "pallet_election_provider_support_benchmarking"
+        # Pallets without automatic benchmarking
+        "pallet_babe" "pallet_grandpa"
+        "pallet_mmr" "pallet_offences"
+    )
+    
+    CUSTOM_PALLETS=()
+    for f in ./pallets/*/Cargo.toml; do
+        pallet_name=$(awk -F' = ' '$1 == "name" {print $2}' $f | tr -d '"' | tr '-' '_')
+        CUSTOM_PALLETS+=($pallet_name)
+    done
+    
+    if ! [ "$PALLETS" = "*" ]; then
+        PALLETS=($PALLETS)
+    fi
+    if [ "$PALLETS" = "*" ]; then
+        PALLETS=($($BINARY_LOCATION benchmark pallet --list --chain=dev | tail -n+2 | cut -d',' -f1 | sort | uniq))
+    fi
+    if ! [ -z "$OUR_PALLETS" ]; then
+        PALLETS=("${CUSTOM_PALLETS[@]}")
+    fi
+}
+
+ERR_FILE="$OUTPUT_PATH/benchmarking_errors.txt"
+
+echo "Building the client in Release mode"
+cargo build --release --locked --features=runtime-benchmarks
+
+populate_pallet_list
+run_benchmark


### PR DESCRIPTION
## Description
To improve our lives I have created a simple script that allows us to automate the benchmarking process. The script is quite simple, by default it runs benchmarks for all pallets with steps set to 50 and repeats set to 20.
```bash
./run_benchmarks.sh
```

You can customize the number of steps and repeats for the benchmarks using
environment variables. For example, to set the number of steps to 4 and the
number of repeats to 20, use the following command:
```bash
STEPS=4 REPEAT=20 ./run_benchmarks.sh
```

If you only want to run benchmarks just for our own custom pallets, you can set the
OUR_PALLETS environment variable:
```bash
OUR_PALLETS=1 ./run_benchmarks.sh
```

To run benchmarks for specific pallets, you need to set the PALLETS environment
variable and provide a space-separated list of pallet names. For example, to run
benchmarks for the frame_system and mocked_runtime pallets, use the following
command:
```bash
PALLETS="frame_system mocked_runtime" ./run_benchmarks.sh
```

## Edit
Closes https://github.com/availproject/engineering/issues/143