### PR TITLE
fix the docker releaser and also build docker image for all architecture

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -129,6 +129,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: availj/avail:${{ steps.prepare.outputs.tag_name }}
+          build-args: |
+            AVAIL_TAG=${{ steps.prepare.outputs.tag_name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,9 +22,8 @@ if [[ ! -z "${RELOAD_KEYSTORE}" ]]; then
 		done;
 fi
 
-echo "Launching validator ${DA_NAME} on chain ${DA_CHAIN}..."
+echo "Launching node ${DA_NAME} on chain ${DA_CHAIN}..."
 ${da_bin} \
-	--validator \
 	--base-path /da/state \
 	--keystore-path ${da_keystore} \
 	--offchain-worker=Always \


### PR DESCRIPTION
This pr fixed the docker release action to have proper tag as the image is always building version1.6.0 of avail regardless of release. Also removed the validator flag from the entrypoint file as that will be passed in runtime so the image can work for both fullnode and validator. Docs along with bash script for the docker to run is separate work in progress.