### PR TITLE
Updated upstream deps to fix the grandpa bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ansi_term",
  "build-helper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "avail-core"
 version = "0.5.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "sp-api",
  "sp-beefy",
@@ -2640,7 +2640,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2663,7 +2663,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "log",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "kate"
 version = "0.8.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.9.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5174,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.4"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "ethers-signers",
  "nomad-core",
@@ -5190,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.4"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "nomad-merkle"
 version = "0.1.2"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "avail-core",
  "frame-support",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "nomad-signature"
 version = "0.1.2"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/grandpa-fix#04f75efceb4ff49856da6c1271c8afe9366449a0"
 dependencies = [
  "elliptic-curve",
  "ethers-core",
@@ -5515,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5531,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5570,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5590,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5605,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5642,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5659,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5677,7 +5677,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5713,7 +5713,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5731,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5754,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5825,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5841,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5858,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5892,7 +5892,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5930,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5953,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5964,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5996,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6015,7 +6015,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "log",
  "sp-core",
@@ -7335,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -7416,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "fnv",
  "futures",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7518,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7581,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -7650,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "log",
  "sc-allocator",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ahash 0.7.6",
  "array-bytes",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ansi_term",
  "futures",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7807,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "cid",
  "futures",
@@ -7868,7 +7868,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ahash 0.7.6",
  "futures",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "libp2p",
@@ -8027,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint 0.10.0-dev",
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8084,7 +8084,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8125,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "directories",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8220,7 +8220,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "libc",
@@ -8239,7 +8239,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "chrono",
  "futures",
@@ -8258,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8289,7 +8289,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8300,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -8340,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "backtrace",
  "futures",
@@ -8787,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "hash-db",
  "log",
@@ -8805,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8844,7 +8844,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8869,7 +8869,7 @@ dependencies = [
 [[package]]
 name = "sp-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8886,7 +8886,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "futures",
  "log",
@@ -8916,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "merlin 2.0.1",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "array-bytes",
  "base58 0.2.0",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "blake2",
  "byteorder",
@@ -9038,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9049,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -9058,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9079,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "bytes",
  "ed25519",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "thiserror",
  "zstd",
@@ -9173,7 +9173,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9205,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9301,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "hash-db",
  "log",
@@ -9333,12 +9333,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9351,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "log",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "ahash 0.7.6",
  "hash-db",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#6fa7fe1326ecaab9921c2c3888530ad679cfbb87"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9626,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -9634,7 +9634,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -9653,7 +9653,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "hyper",
  "log",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -10308,7 +10308,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git/?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+source = "git+https://github.com/availproject/substrate.git/?branch=polkadot-v0.9.37-patch#4747a3634b8dac28b28f0a8e608232c8e8d085dc"
 dependencies = [
  "clap 4.1.6",
  "frame-remote-externalities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 
-[patch."https://github.com/paritytech/substrate.git"]
+[patch."https://github.com/availproject/substrate.git"]
 frame-system = { path = "pallets/system" }
 frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 frame-system-rpc-runtime-api = { path = "pallets/system/rpc/runtime-api" }
@@ -22,136 +22,136 @@ frame-system-rpc-runtime-api = { path = "pallets/system/rpc/runtime-api" }
 frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 
 # DA Primitives
-avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-kate = { version = "0.8", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
+avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
+kate = { version = "0.8", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
+kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
 
 # Nomad
-nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
+nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
+nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
+nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
+nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/grandpa-fix" }
 
 # Other stuff
 uint = { git = "https://github.com/paritytech/parity-common.git", tag = "rlp-v0.5.2" }
 rlp = { git = "https://github.com/paritytech/parity-common.git", tag = "rlp-v0.5.2" }
 
-# Substrate  (polkadot-v0.9.37).
-beefy-merkle-tree = { git = "https://github.com/paritytech/substrate.git/", branch = "polkadot-v0.9.37" }
-sc-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-executor = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-client-db = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-offchain = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-session = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-transaction-storage-proof = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-externalities = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus-epochs = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-network-common = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus-slots = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-consensus-uncles = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-tracing = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-weights = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-sysinfo = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+# Substrate  (polkadot-v0.9.37-patch).
+beefy-merkle-tree = { git = "https://github.com/availproject/substrate.git/", branch = "polkadot-v0.9.37-patch" }
+sc-cli = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-core = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-io = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-std = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-executor = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-service = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-telemetry = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-keystore = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-transaction-pool = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-transaction-pool-api = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-consensus = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-finality-grandpa = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-finality-grandpa = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-client-api = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-client-db = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-runtime = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-runtime-interface = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-timestamp = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-version = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-arithmetic = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-authority-discovery = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-authority-discovery = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-consensus-babe = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-inherents = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-offchain = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-session = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-staking = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-transaction-pool = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-transaction-storage-proof = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-keystore = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-state-machine = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-trie = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-externalities = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-npos-elections = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus-babe = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus-epochs = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus-babe-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-network = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-network-common = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-chain-spec = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus-slots = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-consensus-uncles = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-authorship = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-keyring = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-tracing = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-weights = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-sysinfo = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
 ## Frame
-frame-executive = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-session = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-im-online = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-utility = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-babe = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-indices = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-offences = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-collective = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-bounties = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-tips = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-membership = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-bags-list = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-election-provider-multi-phase = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-frame-election-provider-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-democracy = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-mmr = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-child-bounties = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-preimage = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-nomination-pools = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-election-provider-support-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37", version = "5.0.0-dev" }
+frame-executive = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+frame-support = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+frame-try-runtime = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-balances = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-session = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-im-online = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-grandpa = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-timestamp = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-transaction-payment = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-staking = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-staking-reward-curve = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-utility = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-scheduler = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-babe = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-authorship = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-indices = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-offences = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-treasury = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-collective = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-bounties = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-sudo = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-authority-discovery = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-tips = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-membership = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-elections-phragmen = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-bags-list = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-election-provider-multi-phase = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+frame-election-provider-support = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-democracy = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-mmr = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-multisig = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-child-bounties = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-preimage = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-nomination-pools = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-election-provider-support-benchmarking = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+substrate-wasm-builder = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
 
 
 ## RPCs
-sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-rpc-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-sync-state-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-mmr-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+sc-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-api = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-rpc-api = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-blockchain = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sp-block-builder = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-basic-authorship = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-finality-grandpa-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-sync-state-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+mmr-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-sc-rpc-spec-v2 = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+substrate-frame-rpc-system = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-transaction-payment-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+sc-rpc-spec-v2 = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
 ## These dependencies are used for runtime benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+frame-benchmarking = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+frame-benchmarking-cli = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
 ## CLI
-try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+try-runtime-cli = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
+substrate-build-script-utils = { git = "https://github.com/availproject/substrate.git", branch = "polkadot-v0.9.37-patch" }
 
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates


### PR DESCRIPTION
Crafted a patch based on polkadot-v0.9.37 for Avail's substrate fork, addressing the grandpa bug by cherry-picking the relevant fix. Additionally, I've made updates to the substrate dependencies, switching to a patch branch from our fork for both avail and avail-core.