### PR TITLE
Add devnet workflow

### DIFF
--- a/devnet.yml
+++ b/devnet.yml
@@ -1,0 +1,48 @@
+name: Devnet
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  devnet:
+    if: ${{ github.event.label.name == 'deploy-devnet' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Copy scripts folder to remote server
+      uses: appleboy/scp-action@v0.1.4
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        source: "scripts/"
+        target: "~/"
+        overwrite: true
+
+    - name: Clear previous deployment
+      uses: appleboy/ssh-action@master 
+      with: 
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        command_timeout: "30m"
+        script: |
+          cd ~/scripts
+          bash purge.sh  
+
+
+    - name: Execute deployment script
+      uses: appleboy/ssh-action@master 
+      with: 
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        command_timeout: "60m"
+        script: |
+          cd ~/scripts
+          bash setup.sh ${{ github.event.pull_request.head.sha }} ${{ vars.LC_TAG }} ${{ vars.VAL_COUNT }} ${{ vars.NODE_COUNT }} ${{ vars.LC_COUNT }}

--- a/scripts/consolidate-keys.py
+++ b/scripts/consolidate-keys.py
@@ -1,0 +1,88 @@
+#!/usr/local/bin/python
+import sys
+import json
+
+work_dir = sys.argv[1]
+
+with open(work_dir + "/nodecount.txt", 'r') as node_list:
+    node_data  = node_list.read().splitlines()
+
+
+master_list = {}
+
+for node in node_data:
+    node_info = {}
+    node_info["tag_name"] = node
+    tpl = {
+        "title": "",
+        "category": "SERVER",
+        "sections": [
+            {
+                "id": "wallet",
+                "label": "Wallet"
+            }
+        ],
+        "fields": []
+    }
+
+
+    wallet = {}
+    p2p = {}
+    with open(work_dir + "/" + node_info["tag_name"] + ".wallet.ed25519.json", 'r') as ed25519_wallet:
+        wallet["ed25519"] = json.load(ed25519_wallet)
+    with open(work_dir + "/" + node_info["tag_name"] + ".wallet.sr25519.json", 'r') as sr25519_wallet:
+        wallet["sr25519"] = json.load(sr25519_wallet)
+    with open(work_dir + "/" + node_info["tag_name"] + ".private.key", 'r') as priv_key:
+        p2p["private"] = priv_key.read()
+    with open(work_dir + "/" + node_info["tag_name"] + ".public.key", 'r') as pub_key:
+        p2p["public"] = pub_key.read()
+
+    node_info["wallet"] = wallet
+    node_info["p2p"] = p2p
+    master_list[node_info["tag_name"]] = node_info
+
+    tpl["title"] = "Wallet Credentials for " + node_info["tag_name"]
+    tpl["fields"].append({
+        "id": "notesPlain",
+        "type": "STRING",
+        "purpose": "NOTES",
+        "label": "notesPlain",
+        "value": "These credentials are automatically generated for the avail devnet"
+    })
+    tpl["fields"].append({
+        "id": "recoveryPhrase",
+        "type": "CONCEALED",
+        "label": "Secret Phrase",
+        "value": wallet["sr25519"]["secretPhrase"]
+    })
+    tpl["fields"].append({
+        "id": "walletAddressSr25519",
+        "type": "STRING",
+        "label": "Sr25519 Address",
+        "value": wallet["sr25519"]["ss58PublicKey"]
+    })
+    tpl["fields"].append({
+        "id": "walletAddressEd25519",
+        "type": "STRING",
+        "label": "Ed25519 Address",
+        "value": wallet["ed25519"]["ss58PublicKey"]
+    })
+    tpl["fields"].append({
+        "id": "libP2PPub",
+        "type": "STRING",
+        "label": "Libp2p Public",
+        "value": p2p["public"].strip()
+    })
+    tpl["fields"].append({
+        "id": "libP2PPriv",
+        "label": "Libp2p Private",
+        "type": "CONCEALED",
+        "value": p2p["private"].strip()
+    })
+    with open(work_dir + "/" + node_info["tag_name"] + ".op.tpl.json", 'w') as f:
+        json.dump(tpl, f)
+
+with open(work_dir + "/master.json", 'w') as f:
+    json.dump(master_list, f)
+
+

--- a/scripts/purge.sh
+++ b/scripts/purge.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Finding no of active avail services already present on server to cover edge case of env vars being modified between workflow runs. 
+cd /etc/systemd/system
+TOTAL_COUNT=$(ls -dq *avail* | wc -l)
+
+for (( i=1; i<=$TOTAL_COUNT; i++ ))
+do 
+    sudo systemctl stop avail-val-${i}.service
+    sudo systemctl stop avail-full-${i}.service
+    sudo systemctl stop avail-light-${i}.service
+    sudo systemctl disable avail-light-${i}.service
+    sudo systemctl disable avail-full-${i}.service
+    sudo systemctl disable avail-val-${i}.service
+    sudo rm /etc/systemd/system/avail-val-${i}.service
+    sudo rm /etc/systemd/system/avail-full-${i}.service
+    sudo rm /etc/systemd/system/avail-light-${i}.service
+done
+
+rm -rf $HOME/avail-home
+
+rm -rf $HOME/avail-keys
+
+rm -rf $HOME/avail-apps
+
+rm -rf $HOME/build
+
+rm -rf $HOME/data-avail
+
+rm -rf $HOME/light-bootstrap
+
+rm $HOME/endpoints.txt
+
+sudo rm -rf /var/www/html/*
+
+sudo systemctl daemon-reload

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+
+BUILD_COMMIT=$1
+LC_TAG=$2
+VAL_COUNT=$3
+NODE_COUNT=$4
+LC_COUNT=$5
+
+## Installing prerequisites.
+
+sudo apt-get install make clang pkg-config libssl-dev llvm libudev-dev protobuf-compiler -y 
+sudo apt-get install build-essential jq -y
+sudo apt-get install apache2 -y
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+rustup update nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly
+
+## Cloning and Building data-avail and light client bootstrap binaries.
+
+git clone https://github.com/kaustubhkapatral/avail.git ~/data-avail && cd ~/data-avail
+git checkout $BUILD_COMMIT
+cargo build --release -p data-avail
+cp target/release/data-avail /usr/bin
+cd $HOME
+git clone https://github.com/availproject/avail-light-bootstrap.git ~/light-bootstrap && cd ~/light-bootstrap
+cargo build --release
+cp target/release/avail-light-bootstrap /usr/bin
+cd $HOME
+
+## Downloading light client binary based on system architecture.
+
+export aarch=$(uname -m)
+if [ $aarch == "x86_64" ]
+then
+    wget https://github.com/availproject/avail-light/releases/download/$LC_TAG/avail-light-linux-amd64.tar.gz 
+    tar -xvf avail-light-linux-amd64.tar.gz
+    sudo mv avail-light-linux-amd64 /usr/bin/avail-light
+    rm avail-light-linux-amd64.tar.gz
+fi
+
+if [ $aarch == "aarch64" ]
+then
+    wget https://github.com/availproject/avail-light/releases/download/$LC_TAG/avail-light-linux-aarch64.tar.gz 
+    tar -xvf avail-light-linux-aarch64.tar.gz
+    sudo mv avail-light-linux-aarch64 /usr/bin/avail-light 
+    rm avail-light-linux-aarch64.tar.gz
+fi
+
+## Generating keys for validators, sudo and tech committee.
+
+mkdir $HOME/avail-keys
+
+for (( i=1; i<=$VAL_COUNT; i++ ))
+do 
+    echo "validator-$i" >> $HOME/avail-keys/nodecount.txt
+done
+
+echo "election-01" >> $HOME/avail-keys/nodecount.txt
+echo "sudo-01" >> $HOME/avail-keys/nodecount.txt
+echo "tech-committee-01" >> $HOME/avail-keys/nodecount.txt
+echo "tech-committee-02" >> $HOME/avail-keys/nodecount.txt
+echo "tech-committee-03" >> $HOME/avail-keys/nodecount.txt 
+
+cat $HOME/avail-keys/nodecount.txt | while IFS= read -r node_name; do
+    printf 'Generating keys for %s\n' "$node_name"
+    data-avail key generate --output-type json --scheme Sr25519 -w 21 > $HOME/avail-keys/$node_name.wallet.sr25519.json
+    cat $HOME/avail-keys/$node_name.wallet.sr25519.json | jq -r '.secretPhrase' > $HOME/avail-keys/$node_name.wallet.secret
+    data-avail key generate-node-key 2> $HOME/avail-keys/$node_name.public.key 1> $HOME/avail-keys/$node_name.private.key
+    data-avail key inspect --scheme Ed25519 --output-type json $HOME/avail-keys/$node_name.wallet.secret > $HOME/avail-keys/$node_name.wallet.ed25519.json
+done
+
+cd $HOME/scripts
+python3 consolidate-keys.py $HOME/avail-keys
+
+## Generating dynamic spec.
+
+data-avail build-spec --disable-default-bootnode --chain testnet > $HOME/avail-keys/devnet.template.json
+python3 update-dev-chainspec.py $HOME/avail-keys
+data-avail build-spec --chain=$HOME/avail-keys/populated.devnet.chainspec.json --raw --disable-default-bootnode > $HOME/avail-keys/populated.devnet.chainspec.raw.json
+CHAIN_NAME=$(cat $HOME/avail-keys/populated.devnet.chainspec.raw.json | jq -r .id)
+
+## Imporing respective validator keys into their directories.
+
+mkdir -p $HOME/avail-home/avail-validators
+
+for (( i=1; i<=$VAL_COUNT; i++ ))
+do 
+    mkdir -p $HOME/avail-home/avail-validators/validator-$i/chains/$CHAIN_NAME/network
+    mkdir -p $HOME/avail-home/avail-fullnodes/node-$i/chains/$CHAIN_NAME/network
+    cp $HOME/avail-keys/validator-$i.private.key $HOME/avail-home/avail-validators/validator-$i/chains/$CHAIN_NAME/network/secret_ed25519
+    data-avail key insert --base-path $HOME/avail-home/avail-validators/validator-$i --chain $HOME/avail-keys/populated.devnet.chainspec.raw.json --scheme Sr25519 --suri "$(cat $HOME/avail-keys/validator-${i}.wallet.secret)" --key-type babe
+    data-avail key insert --base-path $HOME/avail-home/avail-validators/validator-$i --chain $HOME/avail-keys/populated.devnet.chainspec.raw.json --scheme Ed25519 --suri "$(cat $HOME/avail-keys/validator-${i}.wallet.secret)" --key-type gran
+    export NODE_KEY=$(cat $HOME/avail-keys/validator-$i.public.key)
+    DIFF=$(($i - 1))
+    INC=$(($DIFF * 2))
+    P2P=$((30335 + $INC))
+    echo "--bootnodes=/ip4/127.0.0.1/tcp/$P2P/p2p/$NODE_KEY" >> $HOME/avail-keys/bootnode.txt
+done
+
+## Generating systemd service files for validators and starting the service.
+
+export IP=$(curl ifconfig.me)
+
+for (( i=1; i<=$VAL_COUNT; i++ ))
+do
+    DIFF=$(($i - 1))
+    INC=$(($DIFF * 2))
+    RPC=$((26657 + $INC))
+    P2P=$((30335 + $INC))
+    WS=$((9045 + $INC))
+    echo "[Unit]
+    Description=Avail val ${i} daemon
+    After=network.target
+    [Service]
+    Type=simple
+    User=$USER
+    ExecStart=$(which data-avail) --ws-port $WS --validator --allow-private-ipv4 --base-path $HOME/avail-home/avail-validators/validator-$i --rpc-port $RPC --port $P2P --chain $HOME/avail-keys/populated.devnet.chainspec.raw.json $(cat $HOME/avail-keys/bootnode.txt) 
+    Restart=on-failure
+    RestartSec=3
+    LimitNOFILE=4096
+    [Install]
+    WantedBy=multi-user.target" | sudo tee "/etc/systemd/system/avail-val-${i}.service"
+
+    sudo systemctl start avail-val-${i}.service
+    echo "Validator $i RPC endpoint is: http://$IP:$RPC" >> $HOME/endpoints.txt
+    echo "Validator $i WS endpoint is : http://$IP:$WS" >> $HOME/endpoints.txt
+done
+
+## Generating systemd service files for full nodes and starting the service.
+
+for (( i=1; i<=$NODE_COUNT; i++ ))
+do
+    mkdir -p $HOME/avail-home/avail-fullnodes/node-$i/chains/$CHAIN_NAME/network
+    DIFF=$(($i - 1))
+    INC=$(($DIFF * 2))
+    RPC=$((9933 + $INC))
+    P2P=$((30135 + $INC))
+    WS=$((9944 + $INC))
+    echo "[Unit]
+    Description=Avail full node daemon
+    After=network.target
+    [Service]
+    Type=simple
+    User=$USER
+    ExecStart=$(which data-avail) --rpc-cors=all --rpc-port $RPC --port $P2P --ws-port $WS --ws-external --rpc-external --unsafe-ws-external --unsafe-rpc-external --allow-private-ipv4 --base-path $HOME/avail-home/avail-fullnodes/node-$i --chain $HOME/avail-keys/populated.devnet.chainspec.raw.json $(cat $HOME/avail-keys/bootnode.txt) 
+    Restart=on-failure
+    RestartSec=3
+    LimitNOFILE=4096
+    [Install]
+    WantedBy=multi-user.target" | sudo tee "/etc/systemd/system/avail-full-${i}.service"
+
+    sudo systemctl start avail-full-${i}.service
+    echo "Fullnode ${i} RPC endpoint is: http://$IP:$RPC" >> $HOME/endpoints.txt
+    echo "Fullnode ${i} WS endpoint is: http://$IP:$WS" >> $HOME/endpoints.txt
+done
+
+## Generate node key and config for light client bootstrap.
+
+data-avail key generate-node-key 2> $HOME/avail-keys/light-client-boot.public.key 1> $HOME/avail-keys/light-client-boot.private.key
+mkdir -p $HOME/avail-home/avail-light/light-1
+echo "log_level = \"info\"
+p2p_port = 3700
+secret_key = { key =  \"$(cat $HOME/avail-keys/light-client-boot.private.key)\" }
+identify_protocol = \"/avail_kad/id/1.0.0\"
+identify_agent = \"avail-light-client/rust-client\"
+kad_connection_idle_timeout = 30
+kad_query_timeout = 60
+avail_path = \"$HOME/avail-home/avail-light/light-1\"
+" | sudo tee "$HOME/avail-home/avail-light/light-1/config.yaml"
+echo "HTTP port of bootstrap light client is: http://$IP:7000" >> $HOME/endpoints.txt
+
+## Generate config files for light clients
+
+for (( i=2; i<=$LC_COUNT; i++ ))
+do
+    mkdir -p $HOME/avail-home/avail-light/light-$i
+    DIFF=$(($i - 1))
+    INC=$(($DIFF * 2))
+    P2P=$((37000 + $INC))
+    PROM=$((9520 + $INC))
+    HTTP=$((7001 + $INC))
+    echo "log_level = \"info\"
+    http_server_host = \"127.0.0.1\"
+    http_server_port = \"$HTTP\"
+    libp2p_seed = 1
+    libp2p_port = \"$P2P\"
+    bootstraps = [[\"$(cat $HOME/avail-keys/light-client-boot.public.key)\", \"/ip4/127.0.0.1/tcp/3700\"]]
+    full_node_ws = [\"ws://127.0.0.1:9944\"]
+    app_id = 0
+    confidence = 92.0
+    prometheus_port = $PROM
+    avail_path = \"$HOME/avail-home/avail-light/light-$i\" " | sudo tee "$HOME/avail-home/avail-light/light-$i/config.yaml" 
+    echo "HTTP port of light client $i is: http://$IP:$HTTP" >> $HOME/endpoints.txt
+done
+
+## Generating systemd service file for bootstrap and starting the service
+
+echo "[Unit]
+Description=Avail light client bootstrap
+After=network.target
+[Service]
+Type=simple
+User=$USER
+ExecStart=$(which avail-light-bootstrap) -C $HOME/avail-home/avail-light/light-1/config.yaml
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=4096
+[Install]
+WantedBy=multi-user.target" | sudo tee "/etc/systemd/system/avail-light-1.service"
+sudo systemctl start avail-light-1.service
+
+## Generating systemd service files for light clients and starting the service
+
+for (( i=2; i<=$LC_COUNT; i++ ))
+do
+    
+    echo "[Unit]
+    Description=Avail light ${i} daemon
+    After=network.target
+    [Service]
+    Type=simple
+    User=$USER
+    ExecStart=$(which avail-light) -c $HOME/avail-home/avail-light/light-$i/config.yaml
+    Restart=on-failure
+    RestartSec=3
+    LimitNOFILE=4096
+    [Install]
+    WantedBy=multi-user.target" | sudo tee "/etc/systemd/system/avail-light-${i}.service"
+
+    sudo systemctl start avail-light-${i}.service
+done
+
+# Setting up the explorer
+cd ~/
+wget https://github.com/availproject/avail-apps/releases/download/v1.6-rc2/avail-explorer.tar.gz
+tar -xvf avail-explorer.tar.gz
+rm avail-explorer.tar.gz
+echo "window.process_env = {"\"WS_URL"\": "\"ws://$IP:9944"\"};" >> build/env-config.js
+sudo cp -r build/* /var/www/html/
+sudo systemctl restart apache2
+echo "Explorer url is http://$IP" >> $HOME/endpoints.txt

--- a/scripts/update-dev-chainspec.py
+++ b/scripts/update-dev-chainspec.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+import sys
+import json
+import uuid
+import re
+
+
+def get_balance_for_node(node_name):
+    if re.match("validator-", node_name) or re.match("election-", node_name):
+        return 1000000000000000000000000
+    return 1000000000000000000000
+
+
+work_dir = sys.argv[1]
+
+
+with open(work_dir + "/devnet.template.json", 'r') as chainspec_file:
+    chainspec = json.load(chainspec_file)
+
+with open(work_dir + "/master.json", 'r') as master_file:
+    nodes = json.load(master_file)
+
+
+chainspec["id"] =  "da_devnet" + "_" + str(uuid.uuid1())
+chainspec["name"] = "Avail-Devnet"
+chainspec["chainType"] = "Live"
+chainspec["protocolId"] = "da1"
+
+rt = chainspec["genesis"]["runtime"]
+
+rt["balances"]["balances"] = []
+rt["staking"]["stakers"] = []
+rt["staking"]["minNominatorBond"] = 10000000000000000000
+rt["staking"]["minValidatorBond"] = 1000000000000000000000
+rt["session"]["keys"] = []
+rt["technicalCommittee"]["members"] = []
+rt["elections"]["members"] = []
+
+for node in nodes:
+    rt["balances"]["balances"].append([
+        nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+        get_balance_for_node(node)
+    ])
+    if re.match("validator-", node):
+        rt["staking"]["stakers"].append([
+            nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+            nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+            1000000000000000000000,
+            "Validator"
+        ])
+        rt["session"]["keys"].append([
+            nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+            nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+            {
+                "babe": nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+                "grandpa": nodes[node]["wallet"]["ed25519"]["ss58PublicKey"],
+                "im_online": nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+                "authority_discovery": nodes[node]["wallet"]["sr25519"]["ss58PublicKey"]
+            }
+        ])
+    if re.match("tech-committee-", node):
+        rt["technicalCommittee"]["members"].append(nodes[node]["wallet"]["sr25519"]["ss58PublicKey"])
+    if re.match("election-", node):
+        rt["elections"]["members"].append([
+            nodes[node]["wallet"]["sr25519"]["ss58PublicKey"],
+            1000000000000000000
+        ])
+
+new_app_keys = []
+for key in rt["dataAvailability"]["appKeys"]:
+    key[1]["owner"] = nodes["sudo-01"]["wallet"]["sr25519"]["ss58PublicKey"]
+    new_app_keys.append(key)
+rt["dataAvailability"]["appKeys"] = new_app_keys
+
+rt["sudo"]["key"] = nodes["sudo-01"]["wallet"]["sr25519"]["ss58PublicKey"]
+
+with open(work_dir + "/populated.devnet.chainspec.json", 'w') as f:
+    json.dump(chainspec, f, indent = 4)
+
+
+


### PR DESCRIPTION
Added a workflow to deploy an ephemeral devnet using the `data-avail` binary built from the latest commit on a PR. This workflow is activated only if a PR has a label attached to it called `deploy-devnet`. Validators, full nodes and light client deployment along with an explorer on a remote server is done by the workflow. 

A few prerequisites have to be setup on the repo level for the workflow to run successfully:-
 - **HOST** Github repository secret containing the ip address or the dns of the remote server on which the devnet is going to be deployed.
 - **KEY** Github repository secret containing the private ssh key used to login to the server. The corresponding public key should be present in `~/.ssh/authorized_keys` of the remote server.
 - **PORT** Github repository secret containing the ssh port of the remote server.
 - **USERNAME** Github repository secret containing the ssh user of the remote server.
 - **VAL_COUNT** Github repository variable containing the total number of validators that need to be setup.
 - **NODE_COUNT** Github repository variable containing the total number of full nodes that need to be setup.
 - **LC_COUNT** Github repository variable containing the total number of light clients that need to be setup.
 - **LC_TAG** Github repository variable containing the release tag of light clients that need to be setup.