### PR TITLE
Updated RPC Response Field Names to Use Camel Case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,8 +531,8 @@ dependencies = [
 
 [[package]]
 name = "avail-core"
-version = "0.5.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.5.1"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -3983,8 +3983,8 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.8.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.8.1"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -4011,8 +4011,8 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.9.0"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.9.1"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -5173,8 +5173,8 @@ dependencies = [
 
 [[package]]
 name = "nomad-base"
-version = "0.1.4"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.1.5"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "ethers-signers",
  "nomad-core",
@@ -5189,8 +5189,8 @@ dependencies = [
 
 [[package]]
 name = "nomad-core"
-version = "0.1.4"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.1.5"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -5252,8 +5252,8 @@ dependencies = [
 
 [[package]]
 name = "nomad-merkle"
-version = "0.1.2"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.1.3"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "avail-core",
  "frame-support",
@@ -5270,8 +5270,8 @@ dependencies = [
 
 [[package]]
 name = "nomad-signature"
-version = "0.1.2"
-source = "git+https://github.com/availproject/avail-core?tag=avail-core/v0.5.0#3e972524dce089d73140a2e32c83084e5c9c418c"
+version = "0.1.3"
+source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
 dependencies = [
  "elliptic-curve",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "avail-core"
 version = "0.5.1"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "kate"
 version = "0.8.1"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.9.1"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -5174,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.5"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "ethers-signers",
  "nomad-core",
@@ -5190,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.5"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "nomad-merkle"
 version = "0.1.3"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "avail-core",
  "frame-support",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "nomad-signature"
 version = "0.1.3"
-source = "git+https://github.com/availproject/avail-core?branch=toufeeq/camelCase#ffb85b5b170db441f338bebf6cfcb3499e0144d0"
+source = "git+https://github.com/availproject/avail-core?branch=main#1c341788275f88aa334c1d674eb029403fa45c52"
 dependencies = [
  "elliptic-curve",
  "ethers-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 
 # DA Primitives
 # TODO: Once the companion PR is merged, change reference to tag
-avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
-kate = { version = "0.8", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
-kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", branch = "main" }
+kate = { version = "0.8", git="https://github.com/availproject/avail-core", branch = "main" }
+kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", branch = "main" }
 
 # Nomad
-nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
-nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
-nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
-nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "main" }
+nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "main" }
+nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "main" }
+nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "main" }
 
 # Other stuff
 uint = { git = "https://github.com/paritytech/parity-common.git", tag = "rlp-v0.5.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,16 @@ frame-system-rpc-runtime-api = { path = "pallets/system/rpc/runtime-api" }
 frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 
 # DA Primitives
-avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-kate = { version = "0.8", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
+# TODO: Once the companion PR is merged, change reference to tag
+avail-core = { version = "0.5", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+kate = { version = "0.8", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+kate-recovery = { version = "0.9", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
 
 # Nomad
-nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
-nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
+nomad-signature = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+nomad-merkle = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+nomad-base = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
+nomad-core = { version = "0.1", git="https://github.com/availproject/avail-core", branch = "toufeeq/camelCase" }
 
 # Other stuff
 uint = { git = "https://github.com/paritytech/parity-common.git", tag = "rlp-v0.5.2" }

--- a/avail-subxt/build_api.sh
+++ b/avail-subxt/build_api.sh
@@ -35,6 +35,8 @@ subxt codegen \
 	--derive-for-type avail_core::AppId=derive_more::From \
 	--url http://localhost:9933 \
 	| sed -En "s/pub struct KateCommitment/#\[serde\(rename_all = \"camelCase\"\)\] \0/p" \
+	| sed -En "s/pub struct HeaderExtension/#\[serde\(rename_all = \"camelCase\"\)\] \0/p" \
+	| sed -En "s/pub struct DataLookupItem/#\[serde\(rename_all = \"camelCase\"\)\] \0/p" \
 	| sed -E '1i \#\[allow(clippy::all)]' \
 	| rustfmt --edition=2021 --emit=stdout > src/api_dev.rs
 echo "🎁 Avail-SubXt API generated in 'src/api_dev.rs'"

--- a/avail-subxt/build_api.sh
+++ b/avail-subxt/build_api.sh
@@ -2,6 +2,7 @@
 echo "⛓ Installing SubXt..."
 cargo install --git https://github.com/paritytech/subxt --tag v0.29.0 subxt-cli || true 
 echo "🔨 Generating Avail-SubXt API from localhost..."
+# TODO: After updating Subxt, verify whether the 'sed' lines can be replaced with the '--attributes-for-type' option.
 subxt codegen \
 	--derive Clone \
 	--derive PartialEq \

--- a/avail-subxt/src/api_dev.rs
+++ b/avail-subxt/src/api_dev.rs
@@ -23107,6 +23107,7 @@ pub mod api {
 					# [codec (crate = :: subxt :: ext :: codec)]
 					#[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
 					#[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+					#[serde(rename_all = "camelCase")]
 					pub struct DataLookupItem {
 						pub app_id: runtime_types::avail_core::AppId,
 						#[codec(compact)]
@@ -23136,6 +23137,7 @@ pub mod api {
 						# [codec (crate = :: subxt :: ext :: codec)]
 						#[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
 						#[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+						#[serde(rename_all = "camelCase")]
 						pub struct HeaderExtension {
 							pub commitment:
 								runtime_types::avail_core::kate_commitment::v1::KateCommitment,

--- a/pallets/system/src/limits.rs
+++ b/pallets/system/src/limits.rs
@@ -44,6 +44,7 @@ use static_assertions::const_assert;
 
 /// Block length limit configuration.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[derive(RuntimeDebug, PartialEq, Clone, PassByCodec, MaxEncodedLen)]
 pub struct BlockLength {
 	/// Maximal total length in bytes for each extrinsic class.


### PR DESCRIPTION
Note: This change is not compatible with the Light Client

avail-core companion: [PR#45](https://github.com/availproject/avail-core/pull/45)
Part of: [Issue #250](https://github.com/availproject/engineering/issues/250)