### PR TITLE
Add semver version constants to DA Runtime for LC compat tracking

### DIFF
--- a/pallets/dactr/src/lib.rs
+++ b/pallets/dactr/src/lib.rs
@@ -61,6 +61,18 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAppDataLength: Get<u32>;
 
+		/// Major version of runtime
+		#[pallet::constant]
+		type AvailRuntimeVersionMajor: Get<u16>;
+
+		/// Minor version of runtime
+		#[pallet::constant]
+		type AvailRuntimeVersionMinor: Get<u16>;
+
+		/// Patch version of runtime
+		#[pallet::constant]
+		type AvailRuntimeVersionPatch: Get<u16>;
+
 		/// Minimum number of rows in a block.
 		#[pallet::constant]
 		type MinBlockRows: Get<BlockLengthRows>;

--- a/pallets/mocked_runtime/src/lib.rs
+++ b/pallets/mocked_runtime/src/lib.rs
@@ -184,6 +184,9 @@ impl da_control::Config for Runtime {
 	type BlockLenProposalId = u32;
 	type MaxAppDataLength = MaxAppDataLength;
 	type MaxAppKeyLength = MaxAppKeyLength;
+	type AvailRuntimeVersionMajor = AvailRuntimeVersionMajor;
+	type AvailRuntimeVersionMinor = AvailRuntimeVersionMinor;
+	type AvailRuntimeVersionPatch = AvailRuntimeVersionPatch;
 	type MaxBlockCols = MaxBlockCols;
 	type MaxBlockRows = MaxBlockRows;
 	type MinBlockCols = MinBlockCols;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -460,6 +460,9 @@ pub mod da {
 	}
 	pub type MaxAppKeyLength = ConstU32<64>;
 	pub type MaxAppDataLength = ConstU32<524_288>; // 512 Kb
+	pub type AvailRuntimeVersionMajor = ConstU16<6>;
+	pub type AvailRuntimeVersionMinor = ConstU16<0>;
+	pub type AvailRuntimeVersionPatch = ConstU16<0>;
 }
 
 pub mod nomad {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -936,6 +936,9 @@ impl pallet_mmr::Config for Runtime {
 }
 
 impl da_control::Config for Runtime {
+	type AvailRuntimeVersionMajor = constants::da::AvailRuntimeVersionMajor;
+	type AvailRuntimeVersionMinor = constants::da::AvailRuntimeVersionMinor;
+	type AvailRuntimeVersionPatch = constants::da::AvailRuntimeVersionPatch;
 	type BlockLenProposalId = u32;
 	type MaxAppDataLength = constants::da::MaxAppDataLength;
 	type MaxAppKeyLength = constants::da::MaxAppKeyLength;


### PR DESCRIPTION
Comments welcome if you have better ideas for naming, automation, etc.