### PR TITLE
Serialize block number to hex string on avail_subxt header.

### DIFF
--- a/avail-subxt/src/primitives/header.rs
+++ b/avail-subxt/src/primitives/header.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use codec::{Decode, Encode};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subxt::{
 	config::{
 		substrate::{BlakeTwo256, Digest, DigestItem},
@@ -19,7 +19,7 @@ use crate::api::runtime_types::{
 #[serde(rename_all = "camelCase")]
 pub struct Header {
 	pub parent_hash: H256,
-	#[serde(deserialize_with = "number_from_hex")]
+	#[serde(serialize_with = "number_to_hex", deserialize_with = "number_from_hex")]
 	#[codec(compact)]
 	pub number: u32,
 	pub state_root: H256,
@@ -48,6 +48,14 @@ impl SPHeader for Header {
 	fn hash(&self) -> <Self::Hasher as Hasher>::Output {
 		Self::Hasher::hash_of(self)
 	}
+}
+
+fn number_to_hex<S>(value: &u32, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	let hex_string = format!("{:X}", value);
+	serializer.serialize_str(&hex_string)
 }
 
 fn number_from_hex<'de, D>(deserializer: D) -> Result<u32, D::Error>


### PR DESCRIPTION
# Header serialization fix in the Avail subxt

## Description

Currently, when user subscribes to finalized headers using avail-subxt, if there is a need to serialize and store the header, serialized header cannot be deserialized. Reason is different serialization and deserialization type.

This PR changes serialization of a number field in the header defined in the avail-subxt, to a hex number string representation instead of a number, to match deserialization function expectations (and RPC format). 

## Testing Performed

Tested on [PR](https://github.com/availproject/avail-light/pull/314) which covers described use case.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
