### PR TITLE
Fix Pull Request Template and Contributing Path

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you encounter a bug or have a feature request, please create an issue using t
 3. **Make Your Changes**: Implement your changes, following our coding standards and guidelines.
 4. **Test Your Changes**: Ensure that your changes are well-tested and don’t break existing functionality.
 5. **Commit Your Changes**: Commit your changes with a descriptive commit message.
-6. **Submit a Pull Request**: Create a pull request against the main repository, filling in the details according to the [pull request template](.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md).
+6. **Submit a Pull Request**: Create a pull request against the main repository, filling in the details according to the [pull request template](./PULL_REQUEST_TEMPLATE.md).
 7. **Address Review Comments**: Respond to any feedback from reviewers, making changes as necessary.
 
 ## Acknowledgments

--- a/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
@@ -8,7 +8,7 @@ assignees: ""
 
 # Bug Report
 
-Check the [contributing guide](../../CONTRIBUTING.md)
+Check the [contributing guide](/.github/CONTRIBUTING.md)
 
 ## Description
 <!-- Provide a clear and concise description of the bug. -->

--- a/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
@@ -8,7 +8,7 @@ assignees: ""
 
 # Feature Request
 
-Check the [contributing guide](../../CONTRIBUTING.md)
+Check the [contributing guide](/.github/CONTRIBUTING.md)
 
 ## Summary
 <!-- Provide a brief summary of the feature you'd like to see added or improved. -->


### PR DESCRIPTION
Hello,

**Description and Related Issues:**
I noticed that the file path for the pull request template and contributing was incorrect, so I made the necessary adjustment. The incorrect file path was causing confusion and potentially preventing contributors from accessing the pull request template. 

This pull request fixes the file path issue by changing it from `.//../PULL_REQUEST_TEMPLATE.md` to `./PULL_REQUEST_TEMPLATE.md`and `../../CONTRIBUTING.md` to `/.github/CONTRIBUTING.md`. 

**Type of PR:** Bugfix
**Testing Performed:** I have tested these changes.

Thank you.
