### PR TITLE
Correcting all typo errors.

### DIFF
--- a/examples/deno/query_proof.ts
+++ b/examples/deno/query_proof.ts
@@ -18,7 +18,7 @@ const submitData = new Promise<[H256, H256]>((res, _) => {
     });
 });
 
-console.log("Submiting TX...");
+console.log("Submitting TX...");
 const [blockHash, txHash] = await submitData;
 console.log(`Finalized block hash ${blockHash} and tx hash ${txHash}`);
 

--- a/pallets/nomination-pools/src/lib.rs
+++ b/pallets/nomination-pools/src/lib.rs
@@ -1346,7 +1346,7 @@ impl<T: Config> RewardPool<T> {
 		//
 		// dot_total_issuance * 10^18 / 10^10 = dot_total_issuance * 10^8
 		//
-		// which, with the current numbers, is a miniscule fraction of the u128 capacity.
+		// which, with the current numbers, is a minuscule fraction of the u128 capacity.
 		//
 		// Thus, adding two values of type reward counter should be safe for ages in a chain like
 		// Polkadot. The important note here is that `reward_pool.last_recorded_reward_counter` only

--- a/pallets/nomination-pools/src/lib.rs
+++ b/pallets/nomination-pools/src/lib.rs
@@ -2696,7 +2696,7 @@ impl<T: Config> Pallet<T> {
 		);
 
 		// This shouldn't fail, but if it does we don't really care. Remaining balance can consist
-		// of unclaimed pending commission, errorneous transfers to the reward account, etc.
+		// of unclaimed pending commission, erroneous transfers to the reward account, etc.
 		let reward_pool_remaining = T::Currency::free_balance(&reward_account);
 		let _ = T::Currency::transfer(
 			&reward_account,

--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -579,7 +579,7 @@ pub mod pallet {
 		KilledAccount { account: T::AccountId },
 		/// On on-chain remark happened.
 		Remarked { sender: T::AccountId, hash: T::Hash },
-		/// On on-chain remark happend called by Root.
+		/// On on-chain remark happened called by Root.
 		RemarkedByRoot { hash: T::Hash },
 	}
 

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -94,7 +94,7 @@ impl pallet_identity::Config for Runtime {
 	type ForceOrigin = EnsureRoot<AccountId>;
 	/// Maximum number of additional fields that may be stored in an ID.
 	type MaxAdditionalFields = MaxAdditionalFields;
-	/// Maxmimum number of registrars allowed in the system.
+	/// Maximum number of registrars allowed in the system.
 	type MaxRegistrars = MaxRegistrars;
 	/// The maximum number of sub-accounts allowed per identified account.
 	type MaxSubAccounts = MaxSubAccounts;

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -15,7 +15,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// attempt to author blocks unless this is equal to its native runtime.
 	authoring_version: 11,
 	/// Per convention: if the runtime behavior changes, increment spec_version
-	/// and set impl_version to 0. This paramenter is typically incremented when
+	/// and set impl_version to 0. This parameter is typically incremented when
 	/// there's an update to the transaction_version.
 	spec_version: 15,
 	/// The version of the implementation of the specification. Nodes can ignore this. It is only

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,7 +78,7 @@ python3 update-dev-chainspec.py $HOME/avail-keys
 data-avail build-spec --chain=$HOME/avail-keys/populated.devnet.chainspec.json --raw --disable-default-bootnode > $HOME/avail-keys/populated.devnet.chainspec.raw.json
 CHAIN_NAME=$(cat $HOME/avail-keys/populated.devnet.chainspec.raw.json | jq -r .id)
 
-## Imporing respective validator keys into their directories.
+## Importing respective validator keys into their directories.
 
 mkdir -p $HOME/avail-home/avail-validators
 


### PR DESCRIPTION
Hi, 

This is a following of #342 
I am not a bot. This is an implementation of the python codespell library. 
I get that having many typos might be hurtfull as it can lead to spam, that is why I corrected all the typos in one go.

This will prevent you from being spammed over and over with typos PR in the future since there won't be any left.

Have a nice evening