### PR TITLE
Added macro for selecting runtime_param

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -133,6 +133,8 @@ default = [ "cli" ]
 header_commitment_corruption = [ "da-runtime/header_commitment_corruption" ]
 fast-runtime = [ "da-runtime/fast-runtime" ]
 cli = [ "clap", "clap_complete", "frame-benchmarking-cli" ]
+# To be used for all dev & test networks
+goldberg = [ "da-runtime/goldberg" ]
 runtime-benchmarks = [
 	"da-control/runtime-benchmarks",
 	"da-runtime/runtime-benchmarks",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -145,6 +145,8 @@ default = [ "std" ]
 with-tracing = [ "frame-executive/with-tracing" ]
 fast-runtime = []
 codspeed = []
+# To be used for all dev & test networks
+goldberg = []
 header_commitment_corruption = [ "frame-system/header_commitment_corruption" ]
 std = [
 	"avail-core/std",

--- a/runtime/src/commons.rs
+++ b/runtime/src/commons.rs
@@ -1,0 +1,35 @@
+/// Macro to set a value (e.g. when using the `parameter_types` macro) to either a production value
+/// or to an environment variable or testing value (in case the `goldberg` feature is selected)
+/// or one of two testing values depending on feature.
+/// Note that the environment variable is evaluated _at compile time_.
+///
+/// Usage:
+/// ```Rust
+/// parameter_types! {
+/// 	// Note that the env variable version parameter cannot be const.
+/// 	pub LaunchPeriod: BlockNumber = prod_or_test!(7 * DAYS, 1, "AVL_LAUNCH_PERIOD");
+/// 	pub const VotingPeriod: BlockNumber = prod_or_test!(7 * DAYS, 1 * MINUTES);
+/// 	pub const EpochDuration: BlockNumber =
+/// 		prod_or_test!(1 * HOURS, "fast-runtime", 1 * MINUTES, "fast-runtime-10m", 10 * MINUTES);
+/// }
+/// ```
+#[macro_export]
+macro_rules! prod_or_test {
+	($prod:expr, $test:expr) => {
+		if cfg!(feature = "goldberg") {
+			$test
+		} else {
+			$prod
+		}
+	};
+	($prod:expr, $test:expr, $env:expr) => {
+		if cfg!(feature = "goldberg") {
+			core::option_env!($env)
+				.map(|s| s.parse().ok())
+				.flatten()
+				.unwrap_or($test)
+		} else {
+			$prod
+		}
+	};
+}

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use crate::prod_or_test;
 use crate::voter_bags;
 use crate::SessionKeys;
 use crate::SLOT_DURATION;
@@ -90,9 +91,8 @@ impl pallet_mandate::Config for Runtime {
 }
 
 parameter_types! {
-	//TODO add flag for different networks
-	pub const StepFunctionId: H256 = H256(hex!("a511bd86a30fa6db581480ac7591d4271c845411ac4e1ad93797d09a57b60522"));
-	pub const RotateFunctionId: H256 = H256(hex!("d7f33a3358d67df3bf792e8b2ab0188d16f4fc07418b35d950407af0d3cb33e0"));
+	pub const StepFunctionId: H256 = prod_or_test!(H256(hex!("22405eefd595d2057393ef9c27a3694839a58b5121cac7e41ed9123a56930c8b")), H256(hex!("a511bd86a30fa6db581480ac7591d4271c845411ac4e1ad93797d09a57b60522")));
+	pub const RotateFunctionId: H256 = prod_or_test!(H256(hex!("c7e13ba912a18fc047292e7698bb2af9c8a2eb901886a785b2cb4b9fd2394573")), H256(hex!("d7f33a3358d67df3bf792e8b2ab0188d16f4fc07418b35d950407af0d3cb33e0")));
 	pub const BridgePalletId: PalletId = PalletId(*b"avl/brdg");
 	pub StepVk: Vec<u8> = r#"{"vk_json":{
     "protocol": "groth16",
@@ -245,7 +245,7 @@ impl pallet_succinct::Config for Runtime {
 	type Currency = Balances;
 	type StepVerificationKey = StepVk;
 	type RotateVerificationKey = RotateVk;
-	type MessageMappingStorageIndex = ConstU64<5>;
+	type MessageMappingStorageIndex = ConstU64<1>;
 	type StepFunctionId = StepFunctionId;
 	type RotateFunctionId = RotateFunctionId;
 	type PalletId = BridgePalletId;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,6 +24,7 @@
 #![allow(macro_expanded_macro_exports_accessed_by_absolute_paths)]
 
 pub mod apis;
+pub mod commons;
 pub mod constants;
 #[cfg(test)]
 mod data_root_tests;


### PR DESCRIPTION
# Pull Request type

- [x] Feature

## Description
A macro for selecting the runtime_paramter value based on whether the `goldberg` feature flag is enabled or not. For all dev & test networks, `goldberg` flag should be enabled while building the binary & wasm.

TODO:
- Update the releaser workflow to build separate binaries for testnet & mainnet
