### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -122,7 +122,7 @@ iai = "0.1.1"
 iai-callgrind = { version = "0.7.3" }
 criterion = "0.5.1"
 codspeed-criterion-compat = "2.2.0"
-divan = "0.1.2"
+divan = "0.1.11"
 
 [[bench]]
 name = "header_kate_commitment_iai_callgrind"

--- a/runtime/benches/header_kate_commitment_divan.rs
+++ b/runtime/benches/header_kate_commitment_divan.rs
@@ -14,11 +14,11 @@ mod commitment_builder {
 		(txs, block_length)
 	}
 
-	#[divan::bench(max_time = 120.0, consts = [ 32, 64, 128, 256 ])]
-	fn columns_count<const N: u32>(bencher: divan::Bencher) {
+	#[divan::bench(max_time = 120.0, args = [ 32, 64, 128, 256 ])]
+	fn columns_count(bencher: divan::Bencher, n: u32) {
 		bencher
-			.counter(N)
-			.with_inputs(|| setup(BlockLengthColumns(N)))
+			.counter(n)
+			.with_inputs(|| setup(BlockLengthColumns(n)))
 			.bench_values(|input| {
 				commitment_builder_with(input.0, input.1);
 			})


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Format
- [ ] Documentation
- [ ] Testing
- [ ] Other:

## Description
<!-- Summarize the changes made in this pull request. Include the motivation for these changes and highlight any key updates. -->
This uses [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) instead of [`consts`](https://docs.rs/divan/latest/divan/attr.bench.html#consts) to improve compile times.

## Related Issues
<!-- List any related issues or bug numbers this pull request is intended to address. Use GitHub's linking feature to automatically close the issues when the pull request is merged (e.g., "Closes #123"). -->

## Testing Performed
<!-- Describe any testing you performed on these changes, including unit tests, integration tests, manual testing, etc. -->

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] The tests pass successfully with `cargo test`.
- [ ] The code was formatted with `cargo fmt`.
- [ ] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [ ] The code has no new warnings when using `cargo clippy`.
- [ ] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
