### PR TITLE
ci:Use GITHUB_OUTPUT over set-output command

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -109,7 +109,7 @@ jobs:
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
-            echo ::set-output name=tag_name::${TAG}
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
       - name: publish binaries
         uses: svenstaro/upload-release-action@v2
@@ -139,7 +139,7 @@ jobs:
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
-            echo ::set-output name=tag_name::${TAG}
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
         uses: docker/login-action@v2


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Format
- [ ] Documentation
- [ ] Testing
- [x] Other:

## Description
<!-- Summarize the changes made in this pull request. Include the motivation for these changes and highlight any key updates. -->

`save-state` and `set-output` commands used in GitHub Actions are
deprecated and [GitHub recommends using environment
files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT` fix the warning in github action.


https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

<img width="1380" alt="image" src="https://github.com/availproject/avail/assets/152680487/36c851d4-cdc2-42c3-86b7-9f165eba6be0">


## Related Issues
<!-- List any related issues or bug numbers this pull request is intended to address. Use GitHub's linking feature to automatically close the issues when the pull request is merged (e.g., "Closes #123"). -->

## Testing Performed
<!-- Describe any testing you performed on these changes, including unit tests, integration tests, manual testing, etc. -->

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] The tests pass successfully with `cargo test`.
- [ ] The code was formatted with `cargo fmt`.
- [ ] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [ ] The code has no new warnings when using `cargo clippy`.
- [ ] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
