### PR TITLE
Fix contributer links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please review and adhere to our [Code of Conduct](./CODE_OF_CONDUCT.md) to maint
 
 ## Reporting Issues
 
-If you encounter a bug or have a feature request, please create an issue using the appropriate [issue template](https://github.com/availproject/avail/issues/new).
+If you encounter a bug or have a feature request, please create an issue using the appropriate [issue template](https://github.com/availproject/avail/issues/new/choose).
 
 ## Submitting Pull Requests
 

--- a/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
@@ -8,7 +8,7 @@ assignees: ""
 
 # Bug Report
 
-Check the [contributing guide](/.github/CONTRIBUTING.md)
+Check the [contributing guide](https://github.com/availproject/avail/blob/main/.github/CONTRIBUTING.md)
 
 ## Description
 <!-- Provide a clear and concise description of the bug. -->

--- a/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
@@ -8,7 +8,7 @@ assignees: ""
 
 # Feature Request
 
-Check the [contributing guide](/.github/CONTRIBUTING.md)
+Check the [contributing guide](https://github.com/availproject/avail/blob/main/.github/CONTRIBUTING.md)
 
 ## Summary
 <!-- Provide a brief summary of the feature you'd like to see added or improved. -->

--- a/avail-js/readme.md
+++ b/avail-js/readme.md
@@ -34,4 +34,4 @@ npm install avail-js-sdk
 
 ## Error Reporting
 
-In case you encounter a bug, don't hesitate to [open an issue](https://github.com/availproject/avail/issues/new) with the maximum amount of detail and we will deal with it as soon as possible.
+In case you encounter a bug, don't hesitate to [open an issue](https://github.com/availproject/avail/issues/new/choose) with the maximum amount of detail and we will deal with it as soon as possible.


### PR DESCRIPTION
Opening an issue template and pressing the contributer guide relative links doesn't work.
For the reporting issue link point to the issue templates.