### PR TITLE
fix: update broken links to docs

### DIFF
--- a/examples/validium/Readme.md
+++ b/examples/validium/Readme.md
@@ -2,7 +2,7 @@
 
 This repository contains examples on how to verify data availability on the Ethereum network.
 More details can be found in the official documentation
-for [Validiums](https://availproject.github.io/using-avail/validiums).
+for [Validiums](https://docs.availproject.org/category/validium/).
 
 Example of submitting data and dispatching data root can be found in [submitData.js](submitData.js).
 This example will submit data transaction to the Avail and try to dispatch data root
@@ -16,7 +16,7 @@ contract [ValidiumContract.sol](contracts%2FValidiumContract.sol).
 
 In order to run these examples, install all necessary dependencies via **npm** 
 and make sure that all variables in **.env** file are populated (`DATA`, `SURI`, etc...), 
-more details in the Avail documentation for [Validiums](https://availproject.github.io/using-avail/validiums#verify-data-availability-on-ethereum).
+more details in the Avail documentation for [Validiums](https://docs.availproject.org/api/use-case-validiums/#verify-data-availability-on-ethereum).
 
 Running submit data example:
 ```bash


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Format
- [X] Documentation
- [ ] Testing
- [ ] Other:

## Description
I've found broken links to Avails docs (validium section), this PR fixes two occurrences of broken link.

## Related Issues
...

## Testing Performed
As the update is only related to docs, no testing should be needed. 

## Checklist
- [X] I have performed a self-review of my own code.
- [X] The tests pass successfully with `cargo test`.
- [X] The code was formatted with `cargo fmt`.
- [X] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [X] The code has no new warnings when using `cargo clippy`.
- [X] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
