### PR TITLE
Updated length_multiplier to use raw block_length

### DIFF
--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -1790,6 +1790,7 @@ impl<T: Config> Pallet<T> {
 		// Remove previous block data from storage
 		BlockWeight::<T>::kill();
 		FailedExtrinsicIndices::<T>::kill();
+		AllExtrinsicsLen::<T>::kill();
 	}
 
 	/// Remove temporary "environment" entries in storage, compute the storage root and return the
@@ -1831,7 +1832,8 @@ impl<T: Config> Pallet<T> {
 			).deconstruct(),
 		);
 		ExecutionPhase::<T>::kill();
-		AllExtrinsicsLen::<T>::kill();
+		// This will be cleared in on_initialise of next block
+		// AllExtrinsicsLen::<T>::kill();
 
 		storage::unhashed::kill(well_known_keys::INTRABLOCK_ENTROPY);
 		// The following fields

--- a/pallets/transaction-payment/src/lib.rs
+++ b/pallets/transaction-payment/src/lib.rs
@@ -320,18 +320,18 @@ where
 		let max_multiplier = X::get();
 		let previous = previous.max(min_multiplier);
 
-		// Considering the padded_length as it consistently serves as a limiting factor compared to block_length and padded_block_length.
+		// Considering the raw_length as it serves as a limiting factor between raw_length and padded_block_length.
 		// Both the Mandatory and Operational classes have a maximum block length set, with no enforced limit on normal transactions.
-		let max_padded_length: u64 = (*DynamicBlockLength::<T>::get()
+		let max_block_length: u64 = (*DynamicBlockLength::<T>::get()
 			.max
 			.get(DispatchClass::Mandatory))
 		.into();
-		let current_block_length = <frame_system::Pallet<T>>::all_padded_extrinsics_len();
+		let current_block_length = <frame_system::Pallet<T>>::all_extrinsics_len();
 
 		let target_block_fullness = S::get();
 		let adjustment_variable = V::get();
 
-		let target_length = (target_block_fullness * max_padded_length) as u128;
+		let target_length = (target_block_fullness * max_block_length) as u128;
 		let block_length = current_block_length as u128;
 
 		log::debug!(target: LOG_TARGET,
@@ -344,7 +344,7 @@ where
 
 		// defensive only, a test case assures that the maximum weight diff can fit in Multiplier
 		// without any saturation.
-		let diff = Multiplier::saturating_from_rational(diff_abs, max_padded_length.max(1));
+		let diff = Multiplier::saturating_from_rational(diff_abs, max_block_length.max(1));
 		let diff_squared = diff.saturating_mul(diff);
 
 		let v_squared_2 = adjustment_variable.saturating_mul(adjustment_variable)


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Other: Logic update

## Description
After [this PR](https://github.com/availproject/avail/pull/359), the limiting factor for BlockLength has been modified from `padded` to `raw`, as `raw` consistently contains a higher value than the `padded` field of AllExtrinsicsLen.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
