### PR TITLE
Decreased block computation capacity

### DIFF
--- a/pallets/system/src/limits.rs
+++ b/pallets/system/src/limits.rs
@@ -549,7 +549,7 @@ impl BlockWeights {
 						Some(Weight::zero())
 					};
 					WeightsPerClass {
-						base_extrinsic: constants::ExtrinsicBaseWeight::get(),
+						base_extrinsic: constants::ExtrinsicBaseWeight::get().saturating_mul(100),
 						max_extrinsic: None,
 						max_total: initial,
 						reserved: initial,

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -131,10 +131,10 @@ pub mod system {
 	const MAXIMUM_BLOCK_WEIGHT: Weight =
 		Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
 
-	/// We allow for 5 seconds of compute with a 20 second average block time, with maximum proof size.
+	/// We allow for 2 (temporary) seconds of compute with a 20 second average block time, with maximum proof size.
 	#[cfg(not(feature = "fast-runtime"))]
 	const MAXIMUM_BLOCK_WEIGHT: Weight =
-		Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(5), u64::MAX);
+		Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
 
 	parameter_types! {
 		pub RuntimeBlockWeights: SystemBlockWeights = SystemBlockWeights::builder()

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -140,7 +140,8 @@ pub mod system {
 		pub RuntimeBlockWeights: SystemBlockWeights = SystemBlockWeights::builder()
 			.base_block(BlockExecutionWeight::get())
 			.for_class(DispatchClass::all(), |weights| {
-				weights.base_extrinsic = ExtrinsicBaseWeight::get();
+				// Note: To make min tx cost at least 0.1 AVAIL, BaseWeight has been increased by 100x
+				weights.base_extrinsic = ExtrinsicBaseWeight::get().saturating_mul(100);
 			})
 			.for_class(DispatchClass::Normal, |weights| {
 				weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -17,7 +17,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// Per convention: if the runtime behavior changes, increment spec_version
 	// and set impl_version to 0. This paramenter is typically incremented when
 	// there's an update to the transaction_version.
-	spec_version: 25,
+	spec_version: 26,
 	// The version of the implementation of the specification. Nodes can ignore this. It is only
 	// used to indicate that the code is different. As long as the authoring_version and the
 	// spec_version are the same, the code itself might have changed, but the native and Wasm


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Other:

## Description
Decreased the block computation capacity by 60%, this will also decrease the DA transaction pricing. (From ~21.5 AVAIL/MB to ~8.5 AVAIL/MB ) and increased the base_weight by 100x to make the min tx cost to 0.1 AVAIL

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
