### PR TITLE
fix: remove ability to send zero amount fungible token messages

### DIFF
--- a/pallets/vector/src/lib.rs
+++ b/pallets/vector/src/lib.rs
@@ -773,6 +773,7 @@ pub mod pallet {
 						SUPPORTED_ASSET_ID == asset_id,
 						Error::<T>::AssetNotSupported
 					);
+					ensure!(amount.saturated_into::<u128>() > 0, Error::<T>::InvalidBridgeInputs);
 					T::Currency::transfer(
 						&who,
 						&Self::account_id(),

--- a/pallets/vector/src/lib.rs
+++ b/pallets/vector/src/lib.rs
@@ -773,7 +773,10 @@ pub mod pallet {
 						SUPPORTED_ASSET_ID == asset_id,
 						Error::<T>::AssetNotSupported
 					);
-					ensure!(amount.saturated_into::<u128>() > 0, Error::<T>::InvalidBridgeInputs);
+					ensure!(
+						amount.saturated_into::<u128>() > 0,
+						Error::<T>::InvalidBridgeInputs
+					);
 					T::Currency::transfer(
 						&who,
 						&Self::account_id(),

--- a/pallets/vector/src/tests.rs
+++ b/pallets/vector/src/tests.rs
@@ -968,6 +968,22 @@ fn send_message_fungible_token_works() {
 }
 
 #[test]
+fn send_message_fungible_token_does_not_accept_zero_amount() {
+	new_test_ext().execute_with(|| {
+		let origin = RuntimeOrigin::signed(TEST_SENDER_VEC.into());
+		let message = Message::FungibleToken {
+			asset_id: H256::zero(),
+			amount: 0,
+		};
+		let to = ROTATE_FUNCTION_ID;
+		let domain = 2;
+
+		let err = Bridge::send_message(origin, message, to, domain);
+		assert_err!(err, Error::<Test>::InvalidBridgeInputs);
+	});
+}
+
+#[test]
 fn execute_arbitrary_message_works() {
 	new_test_ext().execute_with(|| {
 		use crate::BalanceOf;


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [X] Bugfix
- [ ] Refactor
- [ ] Format
- [ ] Documentation
- [ ] Testing
- [ ] Other:

## Description
* This PR removes the ability for users to send send message fungible token extrinsics with zero amounts

## Related Issues
<!-- List any related issues or bug numbers this pull request is intended to address. Use GitHub's linking feature to automatically close the issues when the pull request is merged (e.g., "Closes #123"). -->

## Testing Performed
* Added a negative test-case that checks for the relevant error

## Checklist
- [X] I have performed a self-review of my own code.
- [X] The tests pass successfully with `cargo test`.
- [X] The code was formatted with `cargo fmt`.
- [X] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [X] The code has no new warnings when using `cargo clippy`.
- [X] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
