### PR TITLE
Fix query_proof RPC

### DIFF
--- a/pallets/dactr/src/kate.rs
+++ b/pallets/dactr/src/kate.rs
@@ -120,6 +120,8 @@ pub enum Error {
 	MissingCell { row: u32, col: u32 },
 	#[error("MultiProof error")]
 	Proof,
+	#[error("Failed to extend columns")]
+	ColumnExtension,
 }
 
 impl From<TryFromIntError> for Error {

--- a/pallets/dactr/src/kate/hosted_kate.rs
+++ b/pallets/dactr/src/kate/hosted_kate.rs
@@ -1,5 +1,6 @@
 use super::{AppExtrinsic, AppId, BlockLength, Error, GDataProof, GProof, GRawScalar, GRow, Seed};
 use avail_core::{BlockLengthColumns, BlockLengthRows};
+use core::num::NonZeroU16;
 use frame_system::header_builder::MIN_WIDTH;
 #[cfg(feature = "std")]
 use kate::{
@@ -85,7 +86,10 @@ pub trait HostedKate {
 	) -> Result<Vec<GDataProof>, Error> {
 		let srs = SRS.get_or_init(multiproof_params);
 		let (max_width, max_height) = to_width_height(&block_len);
-		let grid = EGrid::from_extrinsics(extrinsics, MIN_WIDTH, max_width, max_height, seed)?;
+		let grid = EGrid::from_extrinsics(extrinsics, MIN_WIDTH, max_width, max_height, seed)?
+			.extend_columns(NonZeroU16::new(2).expect("2>0"))
+			.map_err(|_| Error::ColumnExtension)?;
+
 		let poly = grid.make_polynomial_grid()?;
 
 		let proofs = cells


### PR DESCRIPTION
# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix

## Description
Kate query_proof RPC was not extending the columns, As a result, we were not able to fetch the proof for extended cells

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
