### PR TITLE
Empty commitments for blocks without any DA extrinsics

### DIFF
--- a/pallets/system/src/header_builder/version_select.rs
+++ b/pallets/system/src/header_builder/version_select.rs
@@ -88,6 +88,10 @@ pub fn build_extension(
 	seed: Seed,
 	version: HeaderVersion,
 ) -> HeaderExtension {
+	// Blocks with non-DA extrinsics will have empty commitments
+	if submitted.is_empty() {
+		return get_empty_header(data_root, version);
+	}
 	let build_extension_start = Instant::now();
 
 	// Build the grid

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -1,5 +1,8 @@
 use avail_base::metrics::avail::KateRpcMetrics;
-use avail_core::{data_proof::ProofResponse, header::HeaderExtension, traits::ExtendedHeader, AppId, OpaqueExtrinsic};
+use avail_core::{
+	data_proof::ProofResponse, header::HeaderExtension, traits::ExtendedHeader, AppId,
+	OpaqueExtrinsic,
+};
 use da_control::kate::{GDataProof, GRow};
 use da_runtime::apis::{DataAvailApi, KateApi as RTKateApi};
 use kate::com::Cell;

--- a/rpc/kate-rpc/src/metrics.rs
+++ b/rpc/kate-rpc/src/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{Cells, HashOf, Kate, KateApiServer, ProofResponse, Rows};
 
-use avail_core::{traits::ExtendedHeader, AppId, OpaqueExtrinsic};
+use avail_core::{header::HeaderExtension, traits::ExtendedHeader, AppId, OpaqueExtrinsic};
 use da_runtime::apis::DataAvailApi;
 
 use crate::RTKateApi;
@@ -60,7 +60,7 @@ where
 impl<Client, Block> KateApiMetricsServer<Block> for Kate<Client, Block>
 where
 	Block: BlockT<Extrinsic = OpaqueExtrinsic>,
-	<Block as BlockT>::Header: ExtendedHeader,
+	<Block as BlockT>::Header: ExtendedHeader<Extension = HeaderExtension>,
 	Client: Send + Sync + 'static,
 	Client: HeaderBackend<Block> + ProvideRuntimeApi<Block> + BlockBackend<Block>,
 	Client::Api: DataAvailApi<Block> + RTKateApi<Block>,


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Feature

## Description
The commitments will be empty with grid dimension [0,0] for blocks without any DA transactions. This is also the case if for any reason [commitment generation fails](https://github.com/availproject/avail/pull/515). In both scenarios, kate `query_rows` and `query_proof` RPCs return an error.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
