### PR TITLE
Change AppUncheckedExtrinsic TryFrom<ExtrinsicDetails> to work with r…

### DIFF
--- a/avail-subxt/src/primitives/app_unchecked_extrinsic.rs
+++ b/avail-subxt/src/primitives/app_unchecked_extrinsic.rs
@@ -128,10 +128,10 @@ impl<'a> Deserialize<'a> for AppUncheckedExtrinsic {
 	}
 }
 
-impl TryFrom<ExtrinsicDetails> for AppUncheckedExtrinsic {
+impl TryFrom<&ExtrinsicDetails> for AppUncheckedExtrinsic {
 	type Error = Error;
 
-	fn try_from(extrinsic: ExtrinsicDetails) -> Result<Self, Self::Error> {
+	fn try_from(extrinsic: &ExtrinsicDetails) -> Result<Self, Self::Error> {
 		let encoded = extrinsic.bytes().encode();
 		Self::decode(&mut encoded.as_slice())
 	}


### PR DESCRIPTION
Change AppUncheckedExtrinsic TryFrom<ExtrinsicDetails> to work with reference, since subxt can't return owned instance (and prevents clone()).

This is needed to avoid some situations in avail-test, where we only get reference. And it also works with owned case, so it's more leniant.

# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Format
- [ ] Documentation
- [ ] Testing
- [ ] Other:

## Description
<!-- Summarize the changes made in this pull request. Include the motivation for these changes and highlight any key updates. -->

## Related Issues
<!-- List any related issues or bug numbers this pull request is intended to address. Use GitHub's linking feature to automatically close the issues when the pull request is merged (e.g., "Closes #123"). -->

## Testing Performed
<!-- Describe any testing you performed on these changes, including unit tests, integration tests, manual testing, etc. -->

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
