### PR TITLE
upgrade checkout action to version with node20

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
       SKIP_WASM_BUILD: true
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -104,7 +104,7 @@ jobs:
       SKIP_WASM_BUILD: true
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         run: |
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event.label.name == 'deploy-devnet' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Copy scripts folder to remote server
       uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
           - command: ENGINE=podman SCRIPT_LOC=./scripts/workflows/e2e_kate.sh ./scripts/workflows/run.sh
           - command: ENGINE=podman SCRIPT_LOC=./scripts/workflows/subxt_examples.sh ./scripts/workflows/run.sh
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -6,7 +6,7 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Copy scripts folder to remote server
       uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/releaser_docker.yml
+++ b/.github/workflows/releaser_docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,7 +6,7 @@ jobs:
     name: "Check"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions-rs/toolchain@v1"
         with:
           override: true
@@ -20,7 +20,7 @@ jobs:
     name: "Rustfmt"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions-rs/toolchain@v1"
         with:
           override: true
@@ -36,7 +36,7 @@ jobs:
     name: "Clippy"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions-rs/toolchain@v1"
         with:
           override: true
@@ -51,7 +51,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_releaser_binaries.yml
+++ b/.github/workflows/test_releaser_binaries.yml
@@ -26,7 +26,7 @@ jobs:
           - command: ENGINE=podman DISTRO=debian-12 ZIP=1 ./scripts/binaries/build.sh
           - command: ENGINE=podman DISTRO=arch ZIP=1 ./scripts/binaries/build.sh
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -45,7 +45,7 @@ jobs:
   arm64_ubuntu_2004:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
   avail_unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -88,7 +88,7 @@ jobs:
   subxt_unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/weights.yml
+++ b/.github/workflows/weights.yml
@@ -18,7 +18,7 @@ jobs:
   benchmark:
     runs-on: [self-hosted, reference]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install deps
         run: |


### PR DESCRIPTION
Node16 is deprecated and Actions using it will stop being used 3rd of June
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/