### PR TITLE
fix typos

### DIFF
--- a/avail-js/examples/readme.md
+++ b/avail-js/examples/readme.md
@@ -57,7 +57,7 @@ npm run query-block-length
 npm run query-rows
 npm run submit-proposal
 npm run staking-nominate
-npm run staking validate
+npm run staking-validate
 npm run estimate-transaction-fees
 npm run validium
 ```

--- a/client/basic-authorship/README.md
+++ b/client/basic-authorship/README.md
@@ -14,7 +14,7 @@ let proposer = proposer_factory.init(
 // The proposer is created asynchronously.
 let proposer = futures::executor::block_on(proposer).unwrap();
 
-// This `Proposer` allows us to create a block proposition.
+// This `Proposer` allows us to create a block proposal.
 // The proposer will grab transactions from the transaction pool, and put them into the block.
 let future = proposer.propose(
 	Default::default(),
@@ -22,7 +22,7 @@ let future = proposer.propose(
 	Duration::from_secs(2),
 );
 
-// We wait until the proposition is performed.
+// We wait until the proposal is performed.
 let block = futures::executor::block_on(future).unwrap();
 println!("Generated block: {:?}", block.block);
 ```


### PR DESCRIPTION
- [x] Documentation

## Description
This pull request corrects typographical errors in two README files:

1. In `avail-js/examples/readme.md`, adjusted the command syntax for `staking_validate` to remove an unnecessary space.
2. In `client/basic-authorship/README.md`, corrected two spelling mistakes:
   - Changed "propostion" to "proposition."
   - Updated "proposistion" to "proposition."

These changes improve the clarity and accuracy of the documentation.

## Testing Performed
These changes were verified manually by reviewing the edited files for accuracy and consistency.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [ ] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).