### PR TITLE
fix: Fix missing quotes in aarch variable checks to prevent potential…

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,7 +28,7 @@ cd $HOME
 ## Downloading light client binary based on system architecture.
 
 export aarch=$(uname -m)
-if [ $aarch == "x86_64" ]
+if [ "$aarch" == "x86_64" ]
 then
     wget https://github.com/availproject/avail-light/releases/download/$LC_TAG/avail-light-linux-amd64.tar.gz 
     tar -xvf avail-light-linux-amd64.tar.gz
@@ -36,7 +36,7 @@ then
     rm avail-light-linux-amd64.tar.gz
 fi
 
-if [ $aarch == "aarch64" ]
+if [ "$aarch" == "aarch64" ]
 then
     wget https://github.com/availproject/avail-light/releases/download/$LC_TAG/avail-light-linux-aarch64.tar.gz 
     tar -xvf avail-light-linux-aarch64.tar.gz


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Format
- [ ] Documentation
- [x] Testing
- [ ] Other:

## Description

While reviewing the code, I noticed that in the section where the value of the `aarch` variable is checked, quotes are missing in the `if` conditions. 

The correct approach should include quotes around the variable to handle cases where `aarch` is empty, avoiding potential syntax errors:  

```bash
if [ "$aarch" == "x86_64" ]
if [ "$aarch" == "aarch64" ]
```  

This small adjustment ensures the script behaves reliably, even in edge cases. 

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
