### PR TITLE
fix: Fix incorrect exit code Update build.sh

### DIFF
--- a/scripts/binaries/build.sh
+++ b/scripts/binaries/build.sh
@@ -13,7 +13,7 @@ if ! test -f "$DOCKER_FILE"; then
     echo "Supported DISTRO: ubuntu-2004 ubuntu-2204 ubuntu-2404 fedora-39 fedora-40 debian-11 debian-12 arch"
     echo "Supported ARCH: x86_64 arm64"
     echo "Supported ENGINE: docker podman"
-    exit 0
+    exit 1
 fi
 
 echo "Selected distro: $DISTRO"


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Format
- [ ] Documentation
- [x] Testing
- [ ] Other:

## Description

I’ve corrected an issue where the script was using `exit 0` after displaying an error message. It’s more appropriate to use `exit 1` to indicate that an error occurred, as a non-zero exit code is expected to signal failure.

## Related Issues

This change ensures that the exit status reflects the actual outcome of the operation.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
