### PR TITLE
Feat(cli): Allow updating network name & id for dev & dev_tri chains

### DIFF
--- a/node/src/chains/mod.rs
+++ b/node/src/chains/mod.rs
@@ -13,8 +13,8 @@ pub mod dev {
 	use da_runtime::wasm_binary_unwrap;
 	use sc_chain_spec::ChainType;
 
-	pub fn chain_spec() -> ChainSpec {
-		ChainSpec::builder(wasm_binary_unwrap(), Default::default())
+	pub fn chain_spec(network_name: Option<String>) -> ChainSpec {
+		let mut builder = ChainSpec::builder(wasm_binary_unwrap(), Default::default())
 			.with_name("Avail Development Network")
 			.with_id("avail_development_network")
 			.with_chain_type(ChainType::Development)
@@ -22,8 +22,13 @@ pub mod dev {
 			.with_telemetry_endpoints(super::to_telemetry_endpoint(TESTNET_TELEMETRY_URL.into()))
 			.with_protocol_id(PROTOCOL_ID)
 			.with_properties(chain_properties())
-			.with_boot_nodes(vec![])
-			.build()
+			.with_boot_nodes(vec![]);
+
+		if let Some(name) = network_name {
+			let id = name.to_lowercase().replace(" ", "_");
+			builder = builder.with_name(&name).with_id(&id);
+		}
+		builder.build()
 	}
 
 	pub fn genesis_constructor() -> Value {
@@ -35,7 +40,7 @@ pub mod dev {
 
 	#[test]
 	fn test_chain_spec_creation() {
-		chain_spec().build_storage().unwrap();
+		chain_spec(None).build_storage().unwrap();
 	}
 }
 
@@ -44,8 +49,8 @@ pub mod dev_tri {
 	use da_runtime::wasm_binary_unwrap;
 	use sc_chain_spec::ChainType;
 
-	pub fn chain_spec() -> ChainSpec {
-		ChainSpec::builder(wasm_binary_unwrap(), Default::default())
+	pub fn chain_spec(network_name: Option<String>) -> ChainSpec {
+		let mut builder = ChainSpec::builder(wasm_binary_unwrap(), Default::default())
 			.with_name("Avail Tri Development Network")
 			.with_id("avail_tri_development_network")
 			.with_chain_type(ChainType::Development)
@@ -53,8 +58,13 @@ pub mod dev_tri {
 			.with_telemetry_endpoints(super::to_telemetry_endpoint(TESTNET_TELEMETRY_URL.into()))
 			.with_protocol_id(PROTOCOL_ID)
 			.with_properties(chain_properties())
-			.with_boot_nodes(vec![])
-			.build()
+			.with_boot_nodes(vec![]);
+
+		if let Some(name) = network_name {
+			let id = name.to_lowercase().replace(" ", "_");
+			builder = builder.with_name(&name).with_id(&id);
+		}
+		builder.build()
 	}
 
 	pub fn genesis_constructor() -> Value {
@@ -73,7 +83,7 @@ pub mod dev_tri {
 
 	#[test]
 	fn test_chain_spec_creation() {
-		chain_spec().build_storage().unwrap();
+		chain_spec(None).build_storage().unwrap();
 	}
 }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -58,6 +58,12 @@ pub struct Cli {
 	/// Max size cannot exceed 10_000
 	#[arg(long, default_value_t = 64, value_parser=kate_max_cells_size_upper_bound)]
 	pub kate_max_cells_size: usize,
+
+	/// The name of the network.
+	///
+	/// This parameter can be used to update the network name and id of the `dev` and `dev_tri` chains.
+	#[arg(long)]
+	pub network_name: Option<String>,
 }
 
 fn kate_max_cells_size_upper_bound(s: &str) -> Result<usize, String> {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -70,8 +70,8 @@ impl SubstrateCli for Cli {
 					"Please specify which chain you want to run, e.g. --chain mainnet".into(),
 				)
 			},
-			"dev" => Box::new(chains::dev::chain_spec()),
-			"dev.tri" => Box::new(chains::dev_tri::chain_spec()),
+			"dev" => Box::new(chains::dev::chain_spec(self.network_name.clone())),
+			"dev.tri" => Box::new(chains::dev_tri::chain_spec(self.network_name.clone())),
 			"devnet0" => Box::new(chains::devnet0::chain_spec()?),
 			"mainnet" => Box::new(chains::mainnet::chain_spec()?),
 			"turing" => Box::new(chains::turing::chain_spec()?),


### PR DESCRIPTION
# Pull Request type

<!-- Check the [contributing guide](../../CONTRIBUTING.md) -->

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Feature

<!--
## Contribution Guidelines
Please note that we currently prioritize substantial contributions over minor changes like lint fixes or typo corrections from new contributors. For larger, impactful contributions, feel free to reach out through our community channels to discuss tasks where your help is most needed.
 -->

## Description
Use the `--network-name` CLI option to update the name and id of development chains such as `dev` and `dev_tri`. This will help in managing and monitoring different ephemeral devnets.

## Related Issues
<!-- List any related issues or bug numbers this pull request is intended to address. Use GitHub's linking feature to automatically close the issues when the pull request is merged (e.g., "Closes #123"). -->

## Testing Performed
<!-- Describe any testing you performed on these changes, including unit tests, integration tests, manual testing, etc. -->

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] The tests pass successfully with `cargo test`.
- [ ] The code was formatted with `cargo fmt`.
- [ ] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [ ] The code has no new warnings when using `cargo clippy`.
- [ ] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
