### PR TITLE
Fix Podman Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ docker run --rm -p 30333:30333 -p 9944:9944 -v ./output:/output:z availnode --de
 ```
 
 ### Podman
-To run the Avail Node using Docker, follow these steps:
+To run the Avail Node using Podman, follow these steps:
 
 ```bash
 # Build the Docker image for the Avail Node:


### PR DESCRIPTION
The text incorrectly states "To run the Avail Node using Docker" when it should refer to "Podman" instead, as this section is specifically about running the Avail Node with Podman. This change ensures clarity and consistency in the documentation.