### PR TITLE
Add binary signing to the releaser

### DIFF
--- a/.github/workflows/releaser_binaries.yml
+++ b/.github/workflows/releaser_binaries.yml
@@ -8,8 +8,43 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Create a job to import and publish the GPG public key
+  setup_gpg:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@ab19e6ac15ddb413f244b6f27bc699903b41f2b2 # v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+            # Export public key
+            gpg --armor --export ${{ steps.import_gpg.outputs.keyid }} > public_key.asc
+
+      - name: Publish public key
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: public_key.asc
+          asset_name: gpg-public-key.asc
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
   build_binaries:
     runs-on: ubuntu-latest
+    needs: setup_gpg
     strategy:
       matrix:
         include:
@@ -35,7 +70,7 @@ jobs:
         with:
           tool-cache: true
       
-      - name: install podman
+      - name: Install podman
         run: sudo apt-get update && sudo apt install podman -y
 
       - uses: nick-fields/retry@v3
@@ -50,7 +85,26 @@ jobs:
             TAG=${GITHUB_REF#refs/tags/}
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
-      - name: publish binary
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@ab19e6ac15ddb413f244b6f27bc699903b41f2b2 # v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Generate checksum and sign binary
+        run: |
+          # Create sha256 checksum
+          cd $(dirname "${{ matrix.output_file }}")
+          FILENAME=$(basename "${{ matrix.output_file }}")
+          sha256sum "$FILENAME" > "${FILENAME}.sha256"
+          
+          # Sign binary and checksum
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign "${FILENAME}"
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign "${FILENAME}.sha256"
+
+      - name: Publish binary
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,8 +113,36 @@ jobs:
           tag: ${{ steps.prepare.outputs.tag_name }}
           overwrite: true
 
+      - name: Publish checksum
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.output_file }}.sha256
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish binary signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.output_file }}.sig
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish checksum signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.output_file }}.sha256.sig
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
   arm64_ubuntu_2004:
     runs-on: ubuntu-20.04
+    needs: setup_gpg
     steps:
       - uses: actions/checkout@v4
 
@@ -74,7 +156,7 @@ jobs:
         with:
           version: '3.x'
 
-      - name: install cargo deps and build avail
+      - name: Install cargo deps and build avail
         shell: bash
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -93,7 +175,25 @@ jobs:
             TAG=${GITHUB_REF#refs/tags/}
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
-      - name: publish binaries
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@ab19e6ac15ddb413f244b6f27bc699903b41f2b2 # v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Generate checksum and sign binary
+        run: |
+          # Create sha256 checksum
+          cd target/aarch64-unknown-linux-gnu/release/
+          sha256sum arm64-ubuntu-2004-avail-node.tar.gz > arm64-ubuntu-2004-avail-node.tar.gz.sha256
+          
+          # Sign binary and checksum
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign arm64-ubuntu-2004-avail-node.tar.gz
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign arm64-ubuntu-2004-avail-node.tar.gz.sha256
+
+      - name: Publish binary
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -102,8 +202,36 @@ jobs:
           tag: ${{ steps.prepare.outputs.tag_name }}
           overwrite: true
 
+      - name: Publish checksum
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2004-avail-node.tar.gz.sha256
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish binary signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2004-avail-node.tar.gz.sig
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish checksum signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2004-avail-node.tar.gz.sha256.sig
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
   arm64_ubuntu_2204:
     runs-on: ubuntu-22.04
+    needs: setup_gpg
     steps:
       - uses: actions/checkout@v4
 
@@ -117,7 +245,7 @@ jobs:
         with:
           version: '3.x'
 
-      - name: install cargo deps and build avail
+      - name: Install cargo deps and build avail
         shell: bash
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -136,11 +264,56 @@ jobs:
             TAG=${GITHUB_REF#refs/tags/}
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
-      - name: publish binaries
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@ab19e6ac15ddb413f244b6f27bc699903b41f2b2 # v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Generate checksum and sign binary
+        run: |
+          # Create sha256 checksum
+          cd target/aarch64-unknown-linux-gnu/release/
+          sha256sum arm64-ubuntu-2204-avail-node.tar.gz > arm64-ubuntu-2204-avail-node.tar.gz.sha256
+          
+          # Sign binary and checksum
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign arm64-ubuntu-2204-avail-node.tar.gz
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
+            --detach-sign arm64-ubuntu-2204-avail-node.tar.gz.sha256
+
+      - name: Publish binary
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish checksum
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sha256
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish binary signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sig
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+
+      - name: Publish checksum signature
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sha256.sig
           release_name: ${{ steps.prepare.outputs.tag_name }}
           tag: ${{ steps.prepare.outputs.tag_name }}
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@
 
 ![demo](./.github/img/terminal.jpg)
 
+## Verifying Avail Node Binary Signatures
+Our release binaries are GPG signed for security. To verify a download:
+
+1. Import our public key. Make sure you change the version to the correct version:
+`curl -s https://github.com/availproject/avail/releases/download/vX.Y.Z/gpg-public-key.asc | gpg --import`
+2. Verify the binary's signature:
+`gpg --verify DOWNLOADED_BINARY.tar.gz.sig DOWNLOADED_BINARY.tar.gz`
+3. Verify the checksum file:
+`gpg --verify YOUR_DOWNLOADED_FILE.tar.gz.sha256.sig YOUR_DOWNLOADED_FILE.tar.gz.sha256`
+4. Verify the checksum:
+`sha256sum -c YOUR_DOWNLOADED_FILE.tar.gz.sha256`
+
+A successful verification will display:
+"Good signature from 'Your Project Release Key `key's email address`'"
+
+You have now verified that the binary is signed by Avail and that its checksum is correct.
+
 ## Running Avail Node
 ### Manually
 


### PR DESCRIPTION
# Add GPG signature verification to release binaries

## Summary
This PR changes the release process by implementing GPG signing for all **binary** artifacts. This allows users to cryptographically verify that binaries were built by our official CI process and haven't been tampered with.

## Changes
- Added a new `setup_gpg` job that imports our signing key and publishes the public key as a release asset
- Modified all build jobs in the releaser to:
  - Generate SHA-256 checksums for each binary
  - Create detached GPG signatures for both binaries and checksums
  - Upload signatures and checksums to GitHub releases alongside binaries
- Added dependency relationships to ensure signing setup completes before build jobs

## Security considerations
- Uses GitHub organization secrets for GPG credentials (key, key ID, and passphrase)
- Pins third-party actions to specific commit hashes for supply chain security (only the one handling keys directly, not the one uploading artifacts because \_O_/)
- Creates a complete verification chain: signed binaries, signed checksums, and published public key

## User impact
Users can now verify the authenticity of our binaries using standard GPG tools. Documentation has been updated with verification instructions.