### PR TITLE
Reintroduced caching to kate RPC's

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -59,6 +59,16 @@ pub struct Cli {
 	#[arg(long, default_value_t = 64, value_parser=kate_max_cells_size_upper_bound)]
 	pub kate_max_cells_size: usize,
 
+	/// The maximum size of the evaluation grid cache in MiB.
+	///
+	#[arg(long, default_value_t = 64)]
+	pub kate_eval_grid_size: u64,
+
+	/// The maximum size of the polynomial grid cache in MiB.
+	///
+	#[arg(long, default_value_t = 64)]
+	pub kate_poly_grid_size: u64,
+
 	/// The name of the network.
 	///
 	/// This parameter can be used to update the network name and id of the `dev` and `dev_tri` chains.
@@ -71,7 +81,7 @@ pub struct Cli {
 	pub tx_state_rpc_enabled: bool,
 
 	/// The maximum number of results the transaction state RPC will return for a transaction hash.
-	/// If a transaction hash appears in multiple blocks, the RPC will return only the top `X` transaction states.  
+	/// If a transaction hash appears in multiple blocks, the RPC will return only the top `X` transaction states.
 	/// In most cases, the transaction hash is unique, so this parameter is usually irrelevant.
 	#[clap(long, default_value_t = 10)]
 	pub tx_state_rpc_max_search_results: usize,

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -233,6 +233,8 @@ where
 		io.merge(KateApiMetricsServer::into_rpc(Kate::<C, Block>::new(
 			client.clone(),
 			kate_rpc_deps.max_cells_size,
+			kate_rpc_deps.eval_grid_size,
+			kate_rpc_deps.poly_grid_size,
 		)))?;
 	}
 
@@ -240,6 +242,8 @@ where
 		io.merge(KateApiServer::into_rpc(Kate::<C, Block>::new(
 			client,
 			kate_rpc_deps.max_cells_size,
+			kate_rpc_deps.eval_grid_size,
+			kate_rpc_deps.poly_grid_size,
 		)))?;
 	}
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -726,6 +726,8 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 		max_cells_size: cli.kate_max_cells_size,
 		rpc_enabled: cli.kate_rpc_enabled,
 		rpc_metrics_enabled: cli.kate_rpc_metrics_enabled,
+		eval_grid_size: cli.kate_eval_grid_size,
+		poly_grid_size: cli.kate_poly_grid_size,
 	};
 	let tx_state_cli_deps = transaction_state::CliDeps {
 		max_search_results: cli.tx_state_rpc_max_search_results,

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -11,10 +11,13 @@ da-runtime.workspace = true
 frame-system = { workspace = true, default-features = false }
 avail-core = { workspace = true, default-features = false }
 kate = { workspace = true, default-features = false }
+kate-recovery = { workspace = true, default-features = false }
 
 # 3rd party
 jsonrpsee.workspace = true
 log.workspace = true
+rayon.workspace = true
+moka = { workspace = true, features = ["future"] }
 
 # Substrate
 sp-api = { workspace = true, default-features = false }

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -161,8 +161,6 @@ macro_rules! internal_err {
 	}}
 }
 
-// ApiRef<'_, dyn ApiExt<Block>>,
-
 type Opaques<B> = Vec<<B as BlockT>::Extrinsic>;
 type Api<'a, C, B> = ApiRef<'a, <C as ProvideRuntimeApi<B>>::Api>;
 
@@ -345,7 +343,6 @@ where
 		}
 
 		let _metric_observer = MetricObserver::new(ObserveKind::KateQueryProof);
-		let start = std::time::Instant::now();
 		let grid = self.get_eval_grid(at).await?;
 		let poly = self.get_poly_grid(at).await?;
 		let srs = SRS.get_or_init(multiproof_params);
@@ -383,7 +380,6 @@ where
 				))
 			})
 			.collect();
-		println!("Proofs generation time: {:?}", start.elapsed());
 		proofs.map_err(|e| internal_err!("Failed to generate proof: {:?}", e))
 	}
 


### PR DESCRIPTION
# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:

- [x] Feature
- [x] Refactor

## Description

Constructing the evaluation grid and polynomial grid is one of the most resource-intensive operations in Kate RPCs. This PR introduces caching for both grids, which optimizes performance for `kate_queryProof` and `kate_queryRows`. The cache sizes for these grids can be configured using the CLI options `--kate-eval-grid-size` and `--kate-poly-grid-size`.

## TODO

Since the implementation of `kate_queryProof` and `kate_queryRows` RPCs has been moved to the client, the runtime APIs currently used by these RPCs should be removed in an upcoming RTU once all nodes have upgraded to binaries containing this version or later.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] The tests pass successfully with `cargo test`.
- [x] The code was formatted with `cargo fmt`.
- [x] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [x] The code has no new warnings when using `cargo clippy`.
- [x] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
