### PR TITLE
fix: replace deprecated #[clap(...)] with #[command(...)] and #[arg(.…

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Cli {
 	pub subcommand: Option<Subcommand>,
 
 	#[allow(missing_docs)]
-	#[clap(flatten)]
+	#[command(flatten)]
 	pub run: sc_cli::RunCmd,
 
 	/// Disable automatic hardware benchmarks.
@@ -42,15 +42,15 @@ pub struct Cli {
 	pub unsafe_da_sync: bool,
 
 	/// Provides storage monitoring options on the node
-	#[clap(flatten)]
+	#[command(flatten)]
 	pub storage_monitor: sc_storage_monitor::StorageMonitorParams,
 
 	/// Enable Kate RPC
-	#[clap(long = "enable-kate-rpc", default_value_t = false)]
+	#[arg(long = "enable-kate-rpc", default_value_t = false)]
 	pub kate_rpc_enabled: bool,
 
 	/// Enable Kate RPC Metrics
-	#[clap(long = "enable-kate-rpc-metrics", default_value_t = false)]
+	#[arg(long = "enable-kate-rpc-metrics", default_value_t = false)]
 	pub kate_rpc_metrics_enabled: bool,
 
 	/// The maximum number of cells that can be requested in one go.


### PR DESCRIPTION
## Description
Closes #750 

## Checklist
- [X] I have performed a self-review of my own code.
- [X] The tests pass successfully with `cargo test`.
- [X] The code was formatted with `cargo fmt`.
- [X] The code compiles with no new warnings with `cargo build --release` and `cargo build --release --features runtime-benchmarks`.
- [X] The code has no new warnings when using `cargo clippy`.
- [X] If this change affects documented features or needs new documentation, I have created a PR with a [documentation update](https://github.com/availproject/availproject.github.io).
