### PR TITLE
Minor Fixes: Typo Correction in Comments and Trace Message

### DIFF
--- a/base/src/mem_tmp_storage.rs
+++ b/base/src/mem_tmp_storage.rs
@@ -68,7 +68,7 @@ pub(crate) mod native {
 	pub static MEM_TMP_STORAGE: RwLock<StorageMap> = RwLock::new(StorageMap::new());
 }
 
-/// The memory temporal storage will be cleared at the begining of each block building.
+/// The memory temporal storage will be cleared at the beginning of each block building.
 ///
 /// This is a simple global database not aware of forks. Can be used for storing auxiliary information like/// the failed `Vector::SendMessage` transaction indexers.
 ///

--- a/e2e/src/tests/max_send_message.rs
+++ b/e2e/src/tests/max_send_message.rs
@@ -56,7 +56,7 @@ async fn max_send_message(
 		.vector()
 		.send_message(message.into(), to_bob, INVALID_DOMAIN);
 	let nonce = alice_nonce().await.fetch_add(max_calls as u64, Relaxed);
-	trace!("Minumum `vector::send_message` call created (invalid domain), reserved nonces {max_calls} from {nonce}");
+	trace!("Minimum `vector::send_message` call created (invalid domain), reserved nonces {max_calls} from {nonce}");
 
 	// Send Txs.
 	let txs_progress = (0..max_calls)


### PR DESCRIPTION


**Description:**  
- Fixed a typo in the comment within `mem_tmp_storage.rs` for clarity.
- Corrected the spelling of "Minimum" in a trace message in `max_send_message.rs`.

