### PR TITLE
Fix typos across codebase: comments, logs, and docs only

### DIFF
--- a/base/src/header_extension/builder_data.rs
+++ b/base/src/header_extension/builder_data.rs
@@ -231,7 +231,7 @@ where
 {
 	let leaves = leaf_iter.collect::<Vec<_>>();
 	let mp = merkle_proof::<Keccak256, _, T>(leaves, leaf_idx);
-	// NOTE: As we are using refrences for the leaves, like `&'a [u8]`, we need to
+	// NOTE: As we are using references for the leaves, like `&'a [u8]`, we need to
 	// convert them to `Vec<u8>`.
 	MerkleProof {
 		root: mp.root,

--- a/base/src/mem_tmp_storage.rs
+++ b/base/src/mem_tmp_storage.rs
@@ -68,7 +68,7 @@ pub(crate) mod native {
 	pub static MEM_TMP_STORAGE: RwLock<StorageMap> = RwLock::new(StorageMap::new());
 }
 
-/// The memory temporal storage will be cleared at the begining of each block building.
+/// The memory temporal storage will be cleared at the beginning of each block building.
 ///
 /// This is a simple global database not aware of forks. Can be used for storing auxiliary information like/// the failed `Vector::SendMessage` transaction indexers.
 ///

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -165,7 +165,7 @@ impl<A, C, PR> ProposerFactory<A, C, PR> {
 	/// The soft deadline indicates where we should stop attempting to add transactions
 	/// to the block, which exhaust resources. After soft deadline is reached,
 	/// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
-	/// transactions which exhaust resrouces, we will conclude that the block is full.
+	/// transactions which exhaust resources, we will conclude that the block is full.
 	///
 	/// Setting the value too low will significantly limit the amount of transactions
 	/// we try in case they exhaust resources. Setting the value too high can

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -80,7 +80,7 @@ mod tests {
 		let ctc = concurrent_controller();
 		let available_permits = ctc.available_permits();
 		let permit = ctc.clone().acquire_owned().await.unwrap();
-		trace!(target: "CTC", "Acquired single permit on `{name}`, it was {available_permits} availabled permits");
+		trace!(target: "CTC", "Acquired single permit on `{name}`, it was {available_permits} available permits");
 		permit
 	}
 

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -104,7 +104,7 @@ mod tests {
 		permit
 	}
 
-	/// Global Concurency controller.
+	/// Global Concurrency controller.
 	fn concurrent_controller() -> Arc<Semaphore> {
 		static CTC: OnceLock<Arc<Semaphore>> = OnceLock::new();
 		Arc::clone(CTC.get_or_init(|| Arc::new(Semaphore::const_new(MAX_PERMITS))))

--- a/e2e/src/tests/max_send_message.rs
+++ b/e2e/src/tests/max_send_message.rs
@@ -56,7 +56,7 @@ async fn max_send_message(
 		.vector()
 		.send_message(message.into(), to_bob, INVALID_DOMAIN);
 	let nonce = alice_nonce().await.fetch_add(max_calls as u64, Relaxed);
-	trace!("Minumum `vector::send_message` call created (invalid domain), reserved nonces {max_calls} from {nonce}");
+	trace!("Minimum `vector::send_message` call created (invalid domain), reserved nonces {max_calls} from {nonce}");
 
 	// Send Txs.
 	let txs_progress = (0..max_calls)

--- a/pallets/system/src/offchain.rs
+++ b/pallets/system/src/offchain.rs
@@ -22,7 +22,7 @@
 //! This module provides transaction related helpers to:
 //! - Submit a raw unsigned transaction
 //! - Submit an unsigned transaction with a signed payload
-//! - Submit a signed transction.
+//! - Submit a signed transaction.
 //!
 //! ## Usage
 //!

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -15,7 +15,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// attempt to author blocks unless this is equal to its native runtime.
 	authoring_version: 12,
 	// Per convention: if the runtime behavior changes, increment spec_version
-	// and set impl_version to 0. This paramenter is typically incremented when
+	// and set impl_version to 0. This parameter is typically incremented when
 	// there's an update to the transaction_version.
 	spec_version: 49,
 	// The version of the implementation of the specification. Nodes can ignore this. It is only


### PR DESCRIPTION


Description
- What: Corrects spelling/grammar in comments and log/trace messages.
- Why: Improves readability and developer experience; clearer logs.
- Examples fixed: references, beginning, resources, available, Concurrency, Minimum, transaction, parameter.

