### PR TITLE
fix: Use Runtime in mocked block type alias

### DIFF
--- a/pallets/mocked_runtime/src/lib.rs
+++ b/pallets/mocked_runtime/src/lib.rs
@@ -26,7 +26,7 @@ pub type Header = avail_core::header::Header<BlockNumber, BlakeTwo256>;
 pub type Signature = sp_runtime::testing::sr25519::Signature;
 pub type TestXt = test_xt::TestXt<RuntimeCall, SignedExtra>;
 pub type UncheckedExtrinsic = TestXt;
-type Block = frame_system::mocking::MockDaBlock<Test>;
+type Block = frame_system::mocking::MockDaBlock<Runtime>;
 pub type SignedExtra = (
 	CheckEra<Runtime>,
 	CheckNonce<Runtime>,


### PR DESCRIPTION
Replace MockDaBlock<Test> with MockDaBlock<Runtime> in pallets/mocked_runtime/src/lib.rs.
Align mocked block alias with the actual mocked runtime (enum Runtime) defined in the file.
Ensures consistency with SignedExtra and other Runtime-parameterized components, preventing a compile-time failure due to an undefined Test type.