### PR TITLE
ci: bind workflow_dispatch inputs via env before shell

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -30,9 +30,11 @@ jobs:
         run: cargo build --release --features try-runtime
 
       - name: Test try-runtime on-runtime-upgrade
+        env:
+          WSENDPOINT: ${{ github.event.inputs.wsendpoint }}
         run: |
           ./target/release/avail-node try-runtime \
           --runtime ./target/release/wbuild/da-runtime/da_runtime.compact.compressed.wasm \
           --chain ./misc/genesis/testnet.kate.chain.spec.raw.json \
           on-runtime-upgrade live \
-          -u ${{ github.event.inputs.wsendpoint }}
+          -u "$WSENDPOINT"

--- a/.github/workflows/weights.yml
+++ b/.github/workflows/weights.yml
@@ -42,15 +42,18 @@ jobs:
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Build node and run benchmarks
+        env:
+          EXTRA_INPUT: ${{ github.event.inputs.extra }}
+          OURPALLETS_INPUT: ${{ github.event.inputs.ourpallets }}
         run: |
-          if [ "${{ github.event.inputs.extra }}" != "0" ]; then
-            EXTRA="EXTRA=${{ github.event.inputs.extra }}"
+          if [ "$EXTRA_INPUT" != "0" ]; then
+            EXTRA="EXTRA=$EXTRA_INPUT"
           else
             EXTRA=""
           fi
 
-          if [ "${{ github.event.inputs.ourpallets }}" != "0" ]; then
-            OUR_PALLETS="OUR_PALLETS=${{ github.event.inputs.ourpallets }}"
+          if [ "$OURPALLETS_INPUT" != "0" ]; then
+            OUR_PALLETS="OUR_PALLETS=$OURPALLETS_INPUT"
           else
             OUR_PALLETS=""
           fi


### PR DESCRIPTION
## Summary
Bind `github.event.inputs.*` into step `env:` before shell use in the try-runtime and weights `workflow_dispatch` workflows.

This follows the common GitHub Actions hardening pattern: keep `${{ }}` expressions out of `run:` scripts so values are not subject to unexpected shell interpolation.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: dry-run `Try Runtime Checks` / `Run benchmarks for weights` with default inputs

Made with [Cursor](https://cursor.com)