### PR TITLE
Improve bridge message handling

### DIFF
--- a/base/src/header_extension/builder_data.rs
+++ b/base/src/header_extension/builder_data.rs
@@ -52,6 +52,7 @@ pub struct HeaderExtensionBuilderData {
 pub struct PostInherentInfo {
 	pub eval_proofs: BTreeMap<u32, Vec<u8>>,
 	pub failed: Vec<u32>,
+	pub successful_bridge_messages: BTreeMap<u32, AddressedMessage>,
 }
 
 impl HeaderExtensionBuilderData {
@@ -76,9 +77,7 @@ impl HeaderExtensionBuilderData {
 		let extracted_tx_datas: Vec<ExtractedTxData> = opaques
 			.into_iter()
 			.enumerate()
-			.filter_map(|(idx, opaque)| {
-				F::filter(post_inherent_info.clone(), opaque.clone(), block, idx)
-			})
+			.filter_map(|(idx, opaque)| F::filter(&post_inherent_info, opaque, block, idx))
 			.collect();
 
 		HeaderExtensionBuilderData::from(extracted_tx_datas)

--- a/base/src/header_extension/traits.rs
+++ b/base/src/header_extension/traits.rs
@@ -3,8 +3,8 @@ use sp_runtime::OpaqueExtrinsic;
 
 pub trait HeaderExtensionDataFilter {
 	fn filter(
-		post_inherent_info: PostInherentInfo,
-		opaque: OpaqueExtrinsic,
+		post_inherent_info: &PostInherentInfo,
+		opaque: &OpaqueExtrinsic,
 		block: u32,
 		tx_idx: usize,
 	) -> Option<ExtractedTxData>;
@@ -15,8 +15,8 @@ pub trait HeaderExtensionDataFilter {
 #[cfg(feature = "std")]
 impl HeaderExtensionDataFilter for () {
 	fn filter(
-		_: PostInherentInfo,
-		_: OpaqueExtrinsic,
+		_: &PostInherentInfo,
+		_: &OpaqueExtrinsic,
 		_: u32,
 		_: usize,
 	) -> Option<ExtractedTxData> {
@@ -30,8 +30,8 @@ impl HeaderExtensionDataFilter for () {
 #[cfg(not(feature = "std"))]
 impl HeaderExtensionDataFilter for () {
 	fn filter(
-		_: PostInherentInfo,
-		_: OpaqueExtrinsic,
+		_: &PostInherentInfo,
+		_: &OpaqueExtrinsic,
 		_: u32,
 		_: usize,
 	) -> Option<ExtractedTxData> {

--- a/node/src/da_block_import.rs
+++ b/node/src/da_block_import.rs
@@ -62,7 +62,7 @@ where
 		}
 	}
 
-	fn ensure_last_extrinsic_is_failed_send_message_txs(
+	fn ensure_last_extrinsic_is_vector_post_inherent(
 		&self,
 		block: &BlockImportParams<B>,
 	) -> Result<(), ConsensusError> {
@@ -259,7 +259,7 @@ where
 		};
 
 		if !is_own && !skip_sync && !block.with_state() {
-			self.ensure_last_extrinsic_is_failed_send_message_txs(&block)?;
+			self.ensure_last_extrinsic_is_vector_post_inherent(&block)?;
 			self.ensure_valid_header_extension(
 				&block,
 				extracted

--- a/pallets/vector/src/lib.rs
+++ b/pallets/vector/src/lib.rs
@@ -1098,12 +1098,20 @@ where
 		let mut expected_prefix = SUCCESSFUL_BRIDGE_MESSAGE_PREFIX.to_vec();
 		expected_prefix.extend_from_slice(&child_number.to_be_bytes());
 		let mut decoded_messages = Vec::new();
-		for (_, value) in data
+		for (key, value) in data
 			.iter()
 			.filter(|(key, _)| key.starts_with(&expected_prefix))
 		{
-			decoded_messages
-				.push(<(Compact<u32>, AddressedMessage)>::decode(&mut value.as_slice()).ok()?);
+			match <(Compact<u32>, AddressedMessage)>::decode(&mut value.as_slice()) {
+				Ok(message) => decoded_messages.push(message),
+				Err(error) => {
+					log::error!(
+						target: LOG_TARGET,
+						"Cannot create successful-message post-inherent: undecodable receipt at authoring key {key:?}: {error}"
+					);
+					return None;
+				},
+			}
 		}
 		let messages = decoded_messages.try_into().ok()?;
 

--- a/pallets/vector/src/lib.rs
+++ b/pallets/vector/src/lib.rs
@@ -8,7 +8,7 @@ use avail_base::{MemoryTemporaryStorage, ProvidePostInherent};
 use avail_core::data_proof::{tx_uid, AddressedMessage, Message, MessageType};
 use sp1_verifier::{Groth16Verifier, GROTH16_VK_BYTES};
 
-use codec::Compact;
+use codec::{Compact, Decode, Encode};
 use frame_support::{
 	pallet_prelude::*,
 	traits::{Currency, ExistenceRequirement, UnixTime},
@@ -52,7 +52,8 @@ pub type ValidProof = BoundedVec<BoundedVec<u8, ConstU32<2048>>, ConstU32<32>>;
 
 // Avail asset is supported for now
 pub const SUPPORTED_ASSET_ID: H256 = H256::zero();
-pub const FAILED_SEND_MSG_ID: &[u8] = b"vector:failed_send_msg_txs";
+pub const MAX_SUCCESSFUL_BRIDGE_MESSAGES: u32 = 1_000;
+pub const SUCCESSFUL_BRIDGE_MESSAGE_PREFIX: &[u8] = b"vector:successful_bridge_message:";
 pub const LOG_TARGET: &str = "runtime::vector";
 pub type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -101,8 +102,12 @@ pub mod pallet {
 		DomainNotSupported,
 		/// Inherent call outside of block execution context.
 		BadContext,
-		/// Invalid FailedIndices
-		InvalidFailedIndices,
+		/// The successful-message post-inherent does not match runtime execution.
+		InvalidSuccessfulMessages,
+		/// More than one bridge message was emitted by the same outer extrinsic.
+		DuplicateMessageId,
+		/// The block already contains the maximum supported number of bridge messages.
+		TooManySuccessfulMessages,
 		/// Invalid updater
 		UpdaterMisMatch,
 		/// Cannot get current message id
@@ -207,6 +212,19 @@ pub mod pallet {
 	/// List of permitted domains.
 	#[pallet::storage]
 	pub type WhitelistedDomains<T> = StorageValue<_, BoundedVec<u32, ConstU32<10_000>>, ValueQuery>;
+
+	/// Bridge messages produced by successful execution in the current block.
+	#[pallet::storage]
+	#[pallet::unbounded]
+	pub type SuccessfulMessagesThisBlock<T> = StorageValue<_, SuccessfulBridgeMessages, ValueQuery>;
+
+	pub type SuccessfulBridgeMessages =
+		BoundedVec<(Compact<u32>, AddressedMessage), ConstU32<MAX_SUCCESSFUL_BRIDGE_MESSAGES>>;
+
+	/// Last outer extrinsic that emitted a bridge message. Kept separately so the duplicate check
+	/// does not decode and scan the potentially large canonical-message accumulator.
+	#[pallet::storage]
+	pub type LastSuccessfulMessageTx<T> = StorageValue<_, u32, OptionQuery>;
 
 	/// Genesis validator root, used to check initialization.
 	#[pallet::storage]
@@ -404,13 +422,9 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
-			if let Some(failed_txs) =
-				MemoryTemporaryStorage::take::<Vec<Compact<u32>>>(FAILED_SEND_MSG_ID)
-			{
-				log::trace!(target: LOG_TARGET, "Failed Txs cleaned: {failed_txs:?}");
-			}
-
-			Weight::zero()
+			SuccessfulMessagesThisBlock::<T>::kill();
+			LastSuccessfulMessageTx::<T>::kill();
+			T::DbWeight::get().writes(2)
 		}
 	}
 
@@ -543,11 +557,13 @@ pub mod pallet {
 		//	send_message_arbitrary_message_doesnt_accept_asset_id(), send_message_arbitrary_message_doesnt_accept_empty_data()
 		#[pallet::call_index(3)]
 		#[pallet::weight({
-			match message {
+			let base = match message {
 				Message::ArbitraryMessage(ref data) => T::WeightInfo::send_message_arbitrary_message(data.len() as u32),
 				Message::FungibleToken{..} => T::WeightInfo::send_message_fungible_token(),
-			}
+			};
+			base.saturating_add(T::DbWeight::get().reads_writes(2, 2))
 		})]
+		#[frame_support::transactional]
 		pub fn send_message(
 			origin: OriginFor<T>,
 			message: Message,
@@ -555,25 +571,7 @@ pub mod pallet {
 			#[pallet::compact] domain: u32,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-
-			let dispatch = Self::do_send_message(who, message, to, domain);
-			if dispatch.is_err() {
-				let _ = MemoryTemporaryStorage::update::<Vec<Compact<u32>>, _>(
-					FAILED_SEND_MSG_ID.to_vec(),
-					|failed| {
-						let tx_idx_result = <frame_system::Pallet<T>>::extrinsic_index();
-						// this should never happen and we can just log warn
-						if tx_idx_result.is_none() {
-							log::warn!(target: LOG_TARGET, "Transaction index is none!");
-						}
-						let tx_idx = tx_idx_result.unwrap_or_default();
-						failed.push(tx_idx.into());
-						log::trace!(target: LOG_TARGET, "Send Message failed txs: {failed:?}");
-					},
-				);
-			}
-
-			dispatch
+			Self::do_send_message(who, message, to, domain)
 		}
 
 		/// set_broadcaster sets the broadcaster address of the message from the origin chain.
@@ -638,22 +636,22 @@ pub mod pallet {
 
 		#[pallet::call_index(11)]
 		#[pallet::weight((
-			T::WeightInfo::failed_tx_index(0u32),
+			T::WeightInfo::successful_send_messages(
+				messages.len() as u32,
+				messages.encoded_size() as u32,
+			).saturating_add(T::DbWeight::get().reads(1)),
 			DispatchClass::Mandatory
 		))]
-		pub fn failed_send_message_txs(
+		pub fn successful_send_messages(
 			origin: OriginFor<T>,
-			failed_txs: Vec<Compact<u32>>,
+			messages: SuccessfulBridgeMessages,
 		) -> DispatchResult {
 			ensure_none(origin)?;
-			let local_failed_txs =
-				MemoryTemporaryStorage::get::<Vec<Compact<u32>>>(FAILED_SEND_MSG_ID)
-					.unwrap_or_default();
+			let local_messages = SuccessfulMessagesThisBlock::<T>::get();
 			ensure!(
-				local_failed_txs == failed_txs,
-				Error::<T>::InvalidFailedIndices
+				local_messages == messages,
+				Error::<T>::InvalidSuccessfulMessages
 			);
-
 			Ok(())
 		}
 
@@ -941,7 +939,10 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> Pallet<T> {
+	impl<T: Config> Pallet<T>
+	where
+		[u8; 32]: From<T::AccountId>,
+	{
 		fn do_send_message(
 			who: T::AccountId,
 			message: Message,
@@ -953,31 +954,69 @@ pub mod pallet {
 				Self::is_domain_valid(domain),
 				Error::<T>::DomainNotSupported
 			);
+			let message_id = Self::fetch_curr_message_id()?;
+			let tx_index = <frame_system::Pallet<T>>::extrinsic_index()
+				.ok_or(Error::<T>::CurrentMessageIdNotFound)?;
+			ensure!(
+				LastSuccessfulMessageTx::<T>::get() != Some(tx_index),
+				Error::<T>::DuplicateMessageId
+			);
+			ensure!(
+				SuccessfulMessagesThisBlock::<T>::decode_len().unwrap_or_default()
+					< MAX_SUCCESSFUL_BRIDGE_MESSAGES as usize,
+				Error::<T>::TooManySuccessfulMessages
+			);
 			// Check MessageType and enforce the rules
 			let message_type = message.r#type();
-			match message {
+			match &message {
 				Message::FungibleToken { asset_id, amount } => {
 					ensure!(
-						SUPPORTED_ASSET_ID == asset_id,
+						SUPPORTED_ASSET_ID == *asset_id,
 						Error::<T>::AssetNotSupported
 					);
 					ensure!(
-						amount.saturated_into::<u128>() > 0,
+						(*amount).saturated_into::<u128>() > 0,
 						Error::<T>::InvalidBridgeInputs
 					);
-					T::Currency::transfer(
-						&who,
-						&Self::account_id(),
-						amount.saturated_into(),
-						ExistenceRequirement::KeepAlive,
-					)?;
 				},
 				Message::ArbitraryMessage(data) => {
 					ensure!(!data.is_empty(), Error::<T>::InvalidBridgeInputs)
 				},
 			};
 
-			let message_id = Self::fetch_curr_message_id()?;
+			let from: [u8; 32] = who.clone().into();
+			let addressed_message = AddressedMessage::new(
+				message,
+				H256(from),
+				to,
+				T::AvailDomain::get(),
+				domain,
+				message_id,
+			);
+			if let Message::FungibleToken { amount, .. } = &addressed_message.message {
+				T::Currency::transfer(
+					&who,
+					&Self::account_id(),
+					(*amount).saturated_into(),
+					ExistenceRequirement::KeepAlive,
+				)?;
+			}
+
+			SuccessfulMessagesThisBlock::<T>::try_append((
+				Compact(tx_index),
+				addressed_message.clone(),
+			))
+			.map_err(|_| Error::<T>::TooManySuccessfulMessages)?;
+			LastSuccessfulMessageTx::<T>::put(tx_index);
+
+			let mut authoring_key = SUCCESSFUL_BRIDGE_MESSAGE_PREFIX.to_vec();
+			let block_number = <frame_system::Pallet<T>>::block_number().saturated_into::<u32>();
+			authoring_key.extend_from_slice(&block_number.to_be_bytes());
+			authoring_key.extend_from_slice(&tx_index.to_be_bytes());
+			let _ = MemoryTemporaryStorage::insert(
+				authoring_key,
+				(Compact(tx_index), addressed_message),
+			);
 
 			Self::deposit_event(Event::MessageSubmitted {
 				from: who,
@@ -1049,24 +1088,37 @@ where
 	type Call = Call<T>;
 	type Error = ();
 
-	fn create_inherent(_: &avail_base::StorageMap) -> Option<Self::Call> {
-		let failed_txs = MemoryTemporaryStorage::get::<Vec<Compact<u32>>>(FAILED_SEND_MSG_ID)
-			.unwrap_or_default();
+	fn create_inherent(data: &avail_base::StorageMap) -> Option<Self::Call> {
+		// This API is currently invoked at the parent hash, while the mirrored receipts were
+		// produced while building its child. Scoping by child number prevents unrelated imports or
+		// stale authoring attempts at other heights from entering this post-inherent.
+		let child_number = <frame_system::Pallet<T>>::block_number()
+			.saturated_into::<u32>()
+			.checked_add(1)?;
+		let mut expected_prefix = SUCCESSFUL_BRIDGE_MESSAGE_PREFIX.to_vec();
+		expected_prefix.extend_from_slice(&child_number.to_be_bytes());
+		let mut decoded_messages = Vec::new();
+		for (_, value) in data
+			.iter()
+			.filter(|(key, _)| key.starts_with(&expected_prefix))
+		{
+			decoded_messages
+				.push(<(Compact<u32>, AddressedMessage)>::decode(&mut value.as_slice()).ok()?);
+		}
+		let messages = decoded_messages.try_into().ok()?;
 
-		log::trace!(target: LOG_TARGET, "Create post inherent failed vector txs: {failed_txs:?}");
-		Some(Call::failed_send_message_txs { failed_txs })
+		log::trace!(target: LOG_TARGET, "Create post inherent successful bridge messages: {messages:?}");
+		Some(Call::successful_send_messages { messages })
 	}
 
 	fn is_inherent(call: &Self::Call) -> bool {
-		matches!(call, Call::failed_send_message_txs { .. })
+		matches!(call, Call::successful_send_messages { .. })
 	}
 
 	fn check_inherent(call: &Self::Call) -> Result<(), Self::Error> {
-		if let Call::failed_send_message_txs { failed_txs } = call {
-			let local_failed_txs =
-				MemoryTemporaryStorage::get::<Vec<Compact<u32>>>(FAILED_SEND_MSG_ID)
-					.unwrap_or_default();
-			ensure!(&local_failed_txs == failed_txs, ());
+		if let Call::successful_send_messages { messages } = call {
+			let local_messages = SuccessfulMessagesThisBlock::<T>::get();
+			ensure!(&local_messages == messages, ());
 		}
 		Ok(())
 	}

--- a/pallets/vector/src/tests.rs
+++ b/pallets/vector/src/tests.rs
@@ -6,12 +6,14 @@ use crate::{
 	state::Configuration,
 	storage_utils::MessageStatusEnum,
 	Broadcasters, ConfigurationStorage, Error, Event, ExecutionStateRoots, Head, Headers,
-	MessageStatus, MockEnabled, ProofOutputs, SP1VerificationKey, SourceChainFrozen, SourceChainId,
-	SyncCommitteeHashes, Updater, ValidProof, WhitelistedDomains,
+	LastSuccessfulMessageTx, MessageStatus, MockEnabled, ProofOutputs, SP1VerificationKey,
+	SourceChainFrozen, SourceChainId, SuccessfulBridgeMessages, SuccessfulMessagesThisBlock,
+	SyncCommitteeHashes, Updater, ValidProof, WhitelistedDomains, MAX_SUCCESSFUL_BRIDGE_MESSAGES,
 };
 use alloy_sol_types::SolValue;
 use avail_core::data_proof::Message::FungibleToken;
 use avail_core::data_proof::{tx_uid, AddressedMessage, Message};
+use codec::{Compact, Encode};
 use frame_support::{
 	assert_err, assert_ok,
 	traits::{fungible::Inspect, DefensiveTruncateFrom},
@@ -642,6 +644,10 @@ fn send_message_arbitrary_message_works() {
 		};
 		let ok = Bridge::send_message(origin, message, to, domain);
 		assert_ok!(ok);
+		let recorded = SuccessfulMessagesThisBlock::<Test>::get();
+		assert_eq!(recorded.len(), 1);
+		assert_eq!(recorded[0].0 .0, 0);
+		assert_eq!(recorded[0].1.id, tx_uid(1, 0));
 		System::assert_last_event(RuntimeEvent::Bridge(event));
 	});
 }
@@ -702,6 +708,88 @@ fn send_message_fungible_token_does_not_accept_zero_amount() {
 
 		let err = Bridge::send_message(origin, message, to, domain);
 		assert_err!(err, Error::<Test>::InvalidBridgeInputs);
+		assert!(SuccessfulMessagesThisBlock::<Test>::get().is_empty());
+	});
+}
+
+#[test]
+fn successful_bridge_message_scale_size_budget() {
+	let fungible = AddressedMessage::new(
+		Message::FungibleToken {
+			asset_id: H256::zero(),
+			amount: u128::MAX,
+		},
+		H256::repeat_byte(1),
+		H256::repeat_byte(2),
+		u32::MAX,
+		u32::MAX,
+		u64::MAX,
+	);
+	let messages: SuccessfulBridgeMessages = (0..MAX_SUCCESSFUL_BRIDGE_MESSAGES)
+		.map(|index| (Compact(index), fungible.clone()))
+		.collect::<Vec<_>>()
+		.try_into()
+		.expect("exactly the configured maximum");
+
+	// This is the accumulator value and the dominant payload of the post-inherent.
+	assert_eq!(messages.encoded_size(), 134_938);
+
+	let max_arbitrary = AddressedMessage::new(
+		Message::ArbitraryMessage(BoundedVec::truncate_from(vec![
+			0;
+			avail_core::data_proof::BOUNDED_DATA_MAX_LENGTH
+				as usize
+		])),
+		H256::repeat_byte(1),
+		H256::repeat_byte(2),
+		u32::MAX,
+		u32::MAX,
+		u64::MAX,
+	);
+	assert_eq!((Compact(u32::MAX), max_arbitrary).encoded_size(), 102_493);
+}
+
+#[test]
+fn send_message_checks_accumulator_capacity_before_transfer() {
+	new_test_ext().execute_with(|| {
+		use crate::BalanceOf;
+		use frame_support::traits::Currency;
+
+		let sender = TEST_SENDER_ACCOUNT;
+		Balances::make_free_balance_be(&sender, BalanceOf::<Test>::max_value() / 2);
+		let balance_before = Balances::free_balance(&sender);
+		let existing = AddressedMessage::new(
+			Message::FungibleToken {
+				asset_id: H256::zero(),
+				amount: 1,
+			},
+			H256::zero(),
+			H256::zero(),
+			1,
+			2,
+			0,
+		);
+		let full: SuccessfulBridgeMessages = (0..MAX_SUCCESSFUL_BRIDGE_MESSAGES)
+			.map(|index| (Compact(index), existing.clone()))
+			.collect::<Vec<_>>()
+			.try_into()
+			.expect("exactly the configured maximum");
+		SuccessfulMessagesThisBlock::<Test>::put(full);
+		LastSuccessfulMessageTx::<Test>::kill();
+
+		assert_err!(
+			Bridge::send_message(
+				RuntimeOrigin::signed(sender.clone()),
+				Message::FungibleToken {
+					asset_id: H256::zero(),
+					amount: 100,
+				},
+				H256::repeat_byte(1),
+				2,
+			),
+			Error::<Test>::TooManySuccessfulMessages
+		);
+		assert_eq!(Balances::free_balance(&sender), balance_before);
 	});
 }
 

--- a/pallets/vector/src/weights.rs
+++ b/pallets/vector/src/weights.rs
@@ -58,7 +58,13 @@ pub trait WeightInfo {
 	fn source_chain_froze() -> Weight;
 	fn execute_fungible_token() -> Weight;
 	fn execute_arbitrary_message(l: u32, ) -> Weight;
-	fn failed_tx_index(_l: u32) -> Weight { Weight::zero() }
+	/// Provisional conservative weight for comparing the bounded canonical receipt list.
+	/// Regenerate this with pallet benchmarks before a production runtime release.
+	fn successful_send_messages(n: u32, bytes: u32) -> Weight {
+		Weight::from_parts(10_000_000, bytes as u64)
+			.saturating_add(Weight::from_parts(50_000, 0).saturating_mul(n as u64))
+			.saturating_add(Weight::from_parts(10_000, 0).saturating_mul(bytes as u64))
+	}
 	fn set_updater() -> Weight;
 	fn set_sp1_verification_key() -> Weight;
 	fn set_sync_committee_hash() -> Weight;

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -432,7 +432,7 @@ impl_runtime_apis! {
 			};
 
 
-			matches!(vector_pallet_call, pallet_vector::Call::failed_send_message_txs {failed_txs: _})
+			matches!(vector_pallet_call, pallet_vector::Call::successful_send_messages {messages: _})
 		}
 
 		fn check_if_extrinsic_is_da_post_inherent(uxt: &<Block as BlockT>::Extrinsic) -> bool {

--- a/runtime/src/header_extension_builder_data_tests.rs
+++ b/runtime/src/header_extension_builder_data_tests.rs
@@ -3,7 +3,7 @@ use crate::extensions::check_batch_transactions::CheckBatchTransactions;
 use crate::{Runtime, SignedExtra, UncheckedExtrinsic};
 
 use avail_base::HeaderExtensionBuilderData;
-use avail_core::data_proof::{BoundedData, Message, TxDataRoots};
+use avail_core::data_proof::{tx_uid, BoundedData, Message, TxDataRoots};
 use da_control::Call as DaCall;
 use frame_system::{
 	CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion,
@@ -217,9 +217,46 @@ fn bridge_fungible_msg(asset_id: H256, amount: u128) -> Vec<u8> {
 	signed_extrinsic(function)
 }
 
-fn bridge_failed_send_message_txs(failed_txs: Vec<u32>) -> Vec<u8> {
-	let failed_txs: Vec<Compact<u32>> = failed_txs.into_iter().map(|i| Compact::from(i)).collect();
-	let function = VectorCall::failed_send_message_txs { failed_txs }.into();
+fn bridge_successful_send_messages(
+	block: u32,
+	extrinsics: &[Vec<u8>],
+	successful_indices: &[u32],
+) -> Vec<u8> {
+	let messages = successful_indices
+		.iter()
+		.filter_map(|tx_index| {
+			let opaque = sp_runtime::OpaqueExtrinsic::try_from_encoded_extrinsic(
+				extrinsics.get(*tx_index as usize)?,
+			)
+			.ok()?;
+			let unchecked = crate::opaque_to_unchecked(&opaque).ok()?;
+			let caller = crate::unchecked_get_caller(&unchecked)?;
+			let RuntimeCall::Vector(VectorCall::send_message {
+				message,
+				to,
+				domain,
+			}) = unchecked.function
+			else {
+				return None;
+			};
+
+			let from: [u8; 32] = *caller.as_ref();
+			Some((
+				Compact(*tx_index),
+				AddressedMessage::new(
+					message,
+					H256(from),
+					to,
+					1,
+					domain,
+					tx_uid(block, *tx_index),
+				),
+			))
+		})
+		.collect::<Vec<_>>()
+		.try_into()
+		.expect("test bridge message count is bounded");
+	let function = VectorCall::successful_send_messages { messages }.into();
 	UncheckedExtrinsic::new_bare(function).encode()
 }
 
@@ -240,7 +277,14 @@ fn empty_root() -> H256 {
 #[test_case(&[submit_blob_metadata(hex!("abcd").to_vec()), bridge_msg(hex!("47").to_vec())] => H256(hex!("c925bfccfc86f15523c5b40b2bd6d8a66fc51f3d41176d77be7928cb9e3831a7")); "submitted and bridged")]
 fn data_root_filter(extrinsics: &[Vec<u8>]) -> H256 {
 	new_test_ext().execute_with(|| {
-		HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, extrinsics).data_root()
+		let mut block_extrinsics = extrinsics.to_vec();
+		let successful_indices = (0..extrinsics.len() as u32).collect::<Vec<_>>();
+		block_extrinsics.push(bridge_successful_send_messages(
+			0,
+			extrinsics,
+			&successful_indices,
+		));
+		HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &block_extrinsics).data_root()
 	})
 }
 
@@ -425,11 +469,12 @@ mod bridge_tests {
 	#[test]
 	fn bridge_message_filter_correctly() {
 		new_test_ext().execute_with(|| {
-			let extrinsics = vec![
+			let mut extrinsics = vec![
 				bridge_msg(b"123".to_vec()),
 				bridge_fungible_msg(H256::zero(), 42_000_000_000_000_000_000u128),
 				submit_blob_metadata(hex!("abcd").to_vec()),
 			];
+			extrinsics.push(bridge_successful_send_messages(0, &extrinsics, &[0, 1]));
 			let data = HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics);
 			let expected = expected_send_arbitrary_data();
 			assert_eq!(data.bridge_messages, expected.bridge_messages);
@@ -441,7 +486,9 @@ mod bridge_tests {
 	#[test]
 	fn bridge_message_is_empty() {
 		new_test_ext().execute_with(|| {
-			let extrinsics: Vec<Vec<u8>> = vec![submit_blob_metadata(hex!("abcd").to_vec())];
+			let mut extrinsics: Vec<Vec<u8>> =
+				vec![submit_blob_metadata(hex!("abcd").to_vec())];
+			extrinsics.push(bridge_successful_send_messages(0, &extrinsics, &[]));
 			let data = HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics);
 			let expected = HeaderExtensionBuilderData::default();
 			assert_eq!(data.bridge_messages, expected.bridge_messages);
@@ -449,16 +496,16 @@ mod bridge_tests {
 		})
 	}
 
-	// Bridges message that are failed (and hence in bridge_failed_send_message_txs) should not generate bridge messages
+	// Raw bridge calls absent from the canonical successful-execution record generate no leaf.
 	#[test]
-	fn bridge_message_filter_failed_tx_correctly() {
+	fn bridge_message_requires_success_record() {
 		new_test_ext().execute_with(|| {
-			let extrinsics = vec![
+			let mut extrinsics = vec![
 				bridge_msg(b"123".to_vec()),
 				bridge_fungible_msg(H256::zero(), 42_000_000_000_000_000_000u128),
 				submit_blob_metadata(hex!("abcd").to_vec()),
-				bridge_failed_send_message_txs(vec![0, 1]),
 			];
+			extrinsics.push(bridge_successful_send_messages(0, &extrinsics, &[]));
 			let data = HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics);
 			let expected: HeaderExtensionBuilderData = HeaderExtensionBuilderData::default();
 			assert_eq!(data.bridge_messages, expected.bridge_messages);
@@ -466,25 +513,25 @@ mod bridge_tests {
 		})
 	}
 
-	// Bridges message and roots should be same for same data and ignore failed txs
+	// Roots depend only on the canonical successful execution record.
 	#[test]
 	fn bridge_roots_should_be_same() {
 		new_test_ext().execute_with(|| {
-			let extrinsics_1 = vec![
+			let mut extrinsics_1 = vec![
 				bridge_msg(b"123".to_vec()),
 				bridge_fungible_msg(H256::zero(), 42_000_000_000_000_000_000u128),
 				bridge_fungible_msg(H256::zero(), 42_000_000_000_000_000_000u128),
 				submit_blob_metadata(hex!("abcd").to_vec()),
-				bridge_failed_send_message_txs(vec![1, 2]),
 			];
+			extrinsics_1.push(bridge_successful_send_messages(0, &extrinsics_1, &[0]));
 			let data_1 =
 				HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics_1);
 
-			let extrinsics_2 = vec![
+			let mut extrinsics_2 = vec![
 				bridge_msg(b"123".to_vec()),
 				submit_blob_metadata(hex!("abcd").to_vec()),
-				bridge_failed_send_message_txs(vec![]),
 			];
+			extrinsics_2.push(bridge_successful_send_messages(0, &extrinsics_2, &[0]));
 			let data_2 =
 				HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics_2);
 
@@ -497,11 +544,12 @@ mod bridge_tests {
 	#[test]
 	fn check_bridge_balanced_tree() {
 		new_test_ext().execute_with(|| {
-			let extrinsics = vec![
+			let mut extrinsics = vec![
 				bridge_msg(b"123".to_vec()),
 				bridge_msg(b"123".to_vec()),
 				bridge_msg(b"123".to_vec()),
 			];
+			extrinsics.push(bridge_successful_send_messages(0, &extrinsics, &[0, 1, 2]));
 			let data = HeaderExtensionBuilderData::from_raw_extrinsics::<Runtime>(0, &extrinsics);
 			let merkle_proof = data.bridged_proof_of(2).unwrap();
 			let proof = merkle_proof.proof;

--- a/runtime/src/transaction_filter.rs
+++ b/runtime/src/transaction_filter.rs
@@ -1,13 +1,11 @@
-use crate::{opaque_to_unchecked, unchecked_get_caller, AccountId, Runtime, RuntimeCall as Call};
+use crate::{opaque_to_unchecked, Runtime, RuntimeCall as Call};
 use avail_base::header_extension::{
 	BridgedData, ExtractedTxData, HeaderExtensionDataFilter, PostInherentInfo, SubmittedData,
 };
-use avail_core::data_proof::{tx_uid, AddressedMessage};
 use sp_runtime::OpaqueExtrinsic;
 
 use da_control::Call as DACall;
 use pallet_vector::Call as VectorCall;
-use sp_core::H256;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::vec::Vec;
 
@@ -15,26 +13,26 @@ use sp_std::vec::Vec;
 /// Bridge messages are only extracted from direct `Vector::send_message` calls.
 impl HeaderExtensionDataFilter for Runtime {
 	fn filter(
-		post_inherent_info: PostInherentInfo,
-		opaque: OpaqueExtrinsic,
-		block: u32,
+		post_inherent_info: &PostInherentInfo,
+		opaque: &OpaqueExtrinsic,
+		_block: u32,
 		tx_index: usize,
 	) -> Option<ExtractedTxData> {
 		let res = opaque_to_unchecked(&opaque);
 		match res {
 			Ok(unchecked_extrinsic) => {
-				let maybe_caller = unchecked_get_caller(&unchecked_extrinsic);
+				let tx_index = u32::try_from(tx_index).ok()?;
+				if let Some(message) = post_inherent_info.successful_bridge_messages.get(&tx_index)
+				{
+					return Some(ExtractedTxData {
+						bridge_data: Some(BridgedData::new(tx_index, message.clone())),
+						..Default::default()
+					});
+				}
 
 				match &unchecked_extrinsic.function {
-					Call::Vector(call) => filter_vector_call(
-						&post_inherent_info.failed,
-						maybe_caller.as_ref(),
-						call,
-						block,
-						tx_index,
-					),
 					Call::DataAvailability(call) => {
-						filter_da_call(call, tx_index, post_inherent_info)
+						filter_da_call(call, tx_index as usize, post_inherent_info)
 					},
 					_ => None,
 				}
@@ -51,18 +49,20 @@ impl HeaderExtensionDataFilter for Runtime {
 	fn get_data_from_post_inherents(opaques: &[OpaqueExtrinsic]) -> PostInherentInfo {
 		let mut failed = Vec::new();
 		let mut eval_proofs = BTreeMap::new();
+		let mut successful_bridge_messages = BTreeMap::new();
 		let len = opaques.len();
 		if len == 0 {
 			return PostInherentInfo::default();
 		}
 
-		// Vector failed transactions
+		// Canonical bridge messages recorded only after successful runtime execution.
 		if let Ok(unchecked_extrinsic) = opaque_to_unchecked(&opaques[len - 1]) {
-			if let Call::Vector(VectorCall::failed_send_message_txs { failed_txs }) =
+			if let Call::Vector(VectorCall::successful_send_messages { messages }) =
 				&unchecked_extrinsic.function
 			{
-				let failed_vector_tx = failed_txs.iter().map(|c| c.0).collect::<Vec<_>>();
-				failed.extend(failed_vector_tx);
+				for (tx_index, message) in messages {
+					successful_bridge_messages.insert(tx_index.0, message.clone());
+				}
 			};
 		};
 
@@ -90,6 +90,7 @@ impl HeaderExtensionDataFilter for Runtime {
 		PostInherentInfo {
 			failed,
 			eval_proofs,
+			successful_bridge_messages,
 		}
 	}
 }
@@ -98,7 +99,7 @@ impl HeaderExtensionDataFilter for Runtime {
 fn filter_da_call(
 	call: &DACall<Runtime>,
 	tx_index: usize,
-	post_inherent_info: PostInherentInfo,
+	post_inherent_info: &PostInherentInfo,
 ) -> Option<ExtractedTxData> {
 	let tx_index = u32::try_from(tx_index).ok()?;
 	if post_inherent_info.failed.contains(&tx_index) {
@@ -143,42 +144,6 @@ fn filter_da_call(
 
 	Some(ExtractedTxData {
 		submitted_data,
-		..Default::default()
-	})
-}
-
-/// Filters and extracts message references from `call`
-fn filter_vector_call(
-	failed_transactions: &[u32],
-	caller: Option<&AccountId>,
-	call: &VectorCall<Runtime>,
-	block: u32,
-	tx_index: usize,
-) -> Option<ExtractedTxData> {
-	let tx_index = u32::try_from(tx_index).ok()?;
-	if failed_transactions.contains(&tx_index) {
-		return None;
-	}
-
-	let VectorCall::send_message {
-		message,
-		to,
-		domain,
-	} = call
-	else {
-		return None;
-	};
-
-	if message.is_empty() {
-		return None;
-	}
-
-	let from: [u8; 32] = *caller?.as_ref();
-	let id = tx_uid(block, tx_index);
-	let msg = AddressedMessage::new(message.clone(), H256(from), *to, 1, *domain, id);
-	let bridge_data = Some(BridgedData::new(tx_index, msg));
-	Some(ExtractedTxData {
-		bridge_data,
 		..Default::default()
 	})
 }


### PR DESCRIPTION
This PR replaces the bridge leaf filtering based on failed transaction indices with a positive, execution-based model. As a result, failed, pasued or rejected `send_message` calls no longer produce bridge leaves. A valid block must contain a post-inherent that exactly matches the successful bridge messages executed by the runtime.