### PR TITLE
ci(release): publish wasm first, cache builds, trim distros to ubuntu/debian

### DIFF
--- a/.github/actions/sign-and-publish/action.yml
+++ b/.github/actions/sign-and-publish/action.yml
@@ -1,0 +1,41 @@
+name: Sign and publish release asset
+description: Checksum, GPG-sign and upload a release asset
+inputs:
+  file:
+    description: Path of the asset to publish
+    required: true
+  gpg_private_key:
+    required: true
+  gpg_passphrase:
+    required: true
+  github_token:
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+      with:
+        gpg_private_key: ${{ inputs.gpg_private_key }}
+        passphrase: ${{ inputs.gpg_passphrase }}
+
+    - name: Checksum and sign
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        GPG_PASSPHRASE: ${{ inputs.gpg_passphrase }}
+      run: |
+        cd "$(dirname "$FILE")"
+        F="$(basename "$FILE")"
+        sha256sum "$F" > "$F.sha256"
+        for f in "$F" "$F.sha256"; do
+          gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --detach-sign "$f"
+        done
+
+    - uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ inputs.github_token }}
+        file: ${{ inputs.file }}*
+        file_glob: true
+        release_name: ${{ github.ref_name }}
+        tag: ${{ github.ref_name }}
+        overwrite: true

--- a/.github/actions/sign-and-publish/action.yml
+++ b/.github/actions/sign-and-publish/action.yml
@@ -5,10 +5,13 @@ inputs:
     description: Path of the asset to publish
     required: true
   gpg_private_key:
+    description: GPG private key used to sign the asset
     required: true
   gpg_passphrase:
+    description: Passphrase for the GPG private key
     required: true
   github_token:
+    description: Token used to upload to the release
     required: true
 runs:
   using: composite

--- a/.github/workflows/releaser_binaries.yml
+++ b/.github/workflows/releaser_binaries.yml
@@ -42,96 +42,44 @@ jobs:
           tag: ${{ steps.prepare.outputs.tag_name }}
           overwrite: true
 
-  build_binaries:
+  wasm:
     runs-on: ${{ vars.BUILD_RUNNER || 'sp1-builder' }}
     needs: setup_gpg
-    strategy:
-      matrix:
-        include:
-          - command: ENGINE=podman SCRIPT_LOC=./scripts/workflows/releaser_wasm.sh ./scripts/workflows/run.sh
-            output_file: output/da_runtime.compact.compressed.wasm
-          - command: ENGINE=podman DISTRO=ubuntu-2204 ZIP=1 ./scripts/binaries/build.sh
-            output_file: output/zips/x86_64-ubuntu-2204-avail-node.tar.gz
-          - command: ENGINE=podman DISTRO=ubuntu-2404 ZIP=1 ./scripts/binaries/build.sh
-            output_file: output/zips/x86_64-ubuntu-2404-avail-node.tar.gz
-          - command: ENGINE=podman DISTRO=fedora-42 ZIP=1 ./scripts/binaries/build.sh
-            output_file: output/zips/x86_64-fedora-42-avail-node.tar.gz
-          - command: ENGINE=podman DISTRO=debian-12 ZIP=1 ./scripts/binaries/build.sh
-            output_file: output/zips/x86_64-debian-12-avail-node.tar.gz
-          - command: ENGINE=podman DISTRO=arch ZIP=1 ./scripts/binaries/build.sh
-            output_file: output/zips/x86_64-arch-avail-node.tar.gz
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install podman
-        run: sudo apt-get update && sudo apt install podman -y
+      - name: Build runtime wasm
+        run: ENGINE=podman DISTRO=ubuntu-2204 CARGO_ARGS="-p da-runtime" ./scripts/binaries/build.sh
+
+      - uses: ./.github/actions/sign-and-publish
+        with:
+          file: output/da_runtime.compact.compressed.wasm
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_binaries:
+    runs-on: ${{ vars.BUILD_RUNNER || 'sp1-builder' }}
+    needs: wasm
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ubuntu-2204, ubuntu-2404, debian-12, debian-13]
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
-          command: ${{ matrix.command }}
+          command: ENGINE=podman DISTRO=${{ matrix.distro }} ZIP=1 ./scripts/binaries/build.sh
 
-      - name: Prepare
-        id: prepare
-        run: |
-            TAG=${GITHUB_REF#refs/tags/}
-            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+      - uses: ./.github/actions/sign-and-publish
         with:
+          file: output/zips/x86_64-${{ matrix.distro }}-avail-node.tar.gz
           gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Generate checksum and sign binary
-        run: |
-          # Create sha256 checksum
-          cd $(dirname "${{ matrix.output_file }}")
-          FILENAME=$(basename "${{ matrix.output_file }}")
-          sha256sum "$FILENAME" > "${FILENAME}.sha256"
-          
-          # Sign binary and checksum
-          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
-            --detach-sign "${FILENAME}"
-          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
-            --detach-sign "${FILENAME}.sha256"
-
-      - name: Publish binary
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.output_file }}
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish checksum
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.output_file }}.sha256
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish binary signature
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.output_file }}.sig
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish checksum signature
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.output_file }}.sha256.sig
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   arm64_ubuntu_2204:
     runs-on: ubuntu-22.04
@@ -153,8 +101,8 @@ jobs:
         shell: bash
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
-          source "$HOME/.cargo/env" && rustup show 
-          
+          source "$HOME/.cargo/env" && rustup show
+
           rustup target add aarch64-unknown-linux-gnu
           sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross
           env  BINDGEN_EXTRA_CLANG_ARGS='--sysroot /usr/aarch64-linux-gnu' CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc cargo build --release --target=aarch64-unknown-linux-gnu -p avail-node
@@ -162,62 +110,9 @@ jobs:
           tar -czf arm64-ubuntu-2204-avail-node.tar.gz avail-node
           popd
 
-      - name: Prepare
-        id: prepare
-        run: |
-            TAG=${GITHUB_REF#refs/tags/}
-            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+      - uses: ./.github/actions/sign-and-publish
         with:
-          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Generate checksum and sign binary
-        run: |
-          # Create sha256 checksum
-          cd target/aarch64-unknown-linux-gnu/release/
-          sha256sum arm64-ubuntu-2204-avail-node.tar.gz > arm64-ubuntu-2204-avail-node.tar.gz.sha256
-          
-          # Sign binary and checksum
-          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
-            --detach-sign arm64-ubuntu-2204-avail-node.tar.gz
-          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --pinentry-mode loopback \
-            --detach-sign arm64-ubuntu-2204-avail-node.tar.gz.sha256
-
-      - name: Publish binary
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish checksum
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sha256
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish binary signature
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sig
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
-
-      - name: Publish checksum signature
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/aarch64-unknown-linux-gnu/release/arm64-ubuntu-2204-avail-node.tar.gz.sha256.sig
-          release_name: ${{ steps.prepare.outputs.tag_name }}
-          tag: ${{ steps.prepare.outputs.tag_name }}
-          overwrite: true
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_releaser_binaries.yml
+++ b/.github/workflows/test_releaser_binaries.yml
@@ -14,14 +14,9 @@ jobs:
   build_binaries:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - command: ENGINE=podman SCRIPT_LOC=./scripts/workflows/releaser_wasm.sh ./scripts/workflows/run.sh
-          - command: ENGINE=podman DISTRO=ubuntu-2204 ZIP=1 ./scripts/binaries/build.sh
-          - command: ENGINE=podman DISTRO=ubuntu-2404 ZIP=1 ./scripts/binaries/build.sh
-          - command: ENGINE=podman DISTRO=fedora-42 ZIP=1 ./scripts/binaries/build.sh
-          - command: ENGINE=podman DISTRO=debian-12 ZIP=1 ./scripts/binaries/build.sh
-          - command: ENGINE=podman DISTRO=arch ZIP=1 ./scripts/binaries/build.sh
+        distro: [ubuntu-2204, ubuntu-2404, debian-12, debian-13]
     steps:
       - uses: actions/checkout@v4
 
@@ -29,15 +24,17 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
-      
-      - name: install podman
-        run: sudo apt-get update && sudo apt install podman -y
+
+      - name: Ensure podman
+        run: command -v podman || (sudo apt-get update && sudo apt-get install -y podman)
 
       - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: ${{ matrix.command }}
+          command: ENGINE=podman DISTRO=${{ matrix.distro }} ZIP=1 ./scripts/binaries/build.sh
+
+      - run: ls -l output/zips output/da_runtime.compact.compressed.wasm
 
   arm64_ubuntu_2204:
     runs-on: ubuntu-22.04
@@ -58,8 +55,8 @@ jobs:
         shell: bash
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
-          source "$HOME/.cargo/env" && rustup show 
-          
+          source "$HOME/.cargo/env" && rustup show
+
           rustup target add aarch64-unknown-linux-gnu
           sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross
           env  BINDGEN_EXTRA_CLANG_ARGS='--sysroot /usr/aarch64-linux-gnu' CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc cargo build --release --target=aarch64-unknown-linux-gnu -p avail-node

--- a/scripts/binaries/build.sh
+++ b/scripts/binaries/build.sh
@@ -1,43 +1,43 @@
 #!/bin/bash
+set -euo pipefail
 
 DISTRO="${DISTRO:-ubuntu-2204}"
 ENGINE="${ENGINE:-docker}"
 ARCH="${ARCH:-x86_64}"
+export CARGO_ARGS="${CARGO_ARGS:-}"
 
-IMAGE="${DISTRO}.Dockerfile"
-DOCKER_FILE="./scripts/binaries/$ARCH/$IMAGE"
+DOCKER_FILE="./scripts/binaries/$ARCH/$DISTRO.Dockerfile"
 DOCKER_IGNORE_FILE="./scripts/binaries/$ARCH/shared.dockerignore"
 
 if ! test -f "$DOCKER_FILE"; then
     echo "Unknown option"
-    echo "Supported DISTRO: ubuntu-2204 ubuntu-2404 fedora-42 debian-12 arch"
-    echo "Supported ARCH: x86_64 arm64"
+    echo "Supported DISTRO: ubuntu-2204 ubuntu-2404 debian-12 debian-13 fedora-42 arch"
+    echo "Supported ARCH: x86_64"
     echo "Supported ENGINE: docker podman"
-    exit 0
+    exit 1
 fi
 
-echo "Selected distro: $DISTRO"
-echo "Selected engine: $ENGINE"
-echo "Selected arch: $ARCH"
-echo "Selected docker file: $DOCKER_FILE"
+OUT="output/$ARCH/$DISTRO"
+mkdir -p "$OUT"
+echo "distro=$DISTRO engine=$ENGINE arch=$ARCH cargo_args='$CARGO_ARGS'"
 
-mkdir -p "output/$ARCH/$DISTRO"
+"$ENGINE" build -t "avail-builder-$DISTRO" --ignorefile="$DOCKER_IGNORE_FILE" -f "$DOCKER_FILE" .
 
-# Build the image
-"$ENGINE" build -t availnodet --ignorefile=$DOCKER_IGNORE_FILE -f $DOCKER_FILE .
+Z=""
+selinuxenabled 2>/dev/null && Z=":z"
 
+"$ENGINE" run --rm -e CARGO_ARGS -e OUT="$OUT" \
+    -v "$PWD:/workdir$Z" \
+    -v "avail-cargo-registry:/root/.cargo/registry" \
+    -v "avail-target-$DISTRO:/workdir/target" \
+    -w /workdir "avail-builder-$DISTRO" bash -ec '
+        git config --global --add safe.directory /workdir
+        cargo build --locked --release $CARGO_ARGS
+        cp target/release/wbuild/da-runtime/da_runtime.compact.compressed.wasm output/
+        [ -n "$CARGO_ARGS" ] || cp target/release/avail-node "$OUT/"
+    '
 
-selinuxenabled
-if [ $? -ne 0 ]; then
-    "$ENGINE" run --rm -v ./output/$ARCH/$DISTRO:/output availnodet
-else
-    "$ENGINE" run --rm -v ./output/$ARCH/$DISTRO:/output:z availnodet
-fi
-
-
-if  [[ "$ZIP" ]]; then
-    mkdir -p ./output/zips/
-    
-    cd ./output/$ARCH/$DISTRO
-    tar -czf ./../../../output/zips/${ARCH}-${DISTRO}-avail-node.tar.gz avail-node
+if [[ "${ZIP:-}" && -f "$OUT/avail-node" ]]; then
+    mkdir -p output/zips
+    tar -C "$OUT" -czf "output/zips/${ARCH}-${DISTRO}-avail-node.tar.gz" avail-node
 fi

--- a/scripts/binaries/x86_64/arch.Dockerfile
+++ b/scripts/binaries/x86_64/arch.Dockerfile
@@ -1,23 +1,10 @@
-# This is the first stage. Here we install all the dependencies that we need in order to build the Ternoa binary.
-FROM registry.hub.docker.com/archlinux/archlinux:latest AS builder
+FROM registry.hub.docker.com/archlinux/archlinux:latest
 
-# This installs all dependencies that we need (besides Rust).
-RUN pacman -Syu --noconfirm git clang curl cmake make protobuf -y
+RUN pacman -Syu --noconfirm git clang curl cmake make protobuf
 
-# This installs Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && chmod u+x rust_install.sh && ./rust_install.sh -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
 
-ADD . ./workdir
-WORKDIR "/workdir"
-
-# This install the right toolchain
-RUN $HOME/.cargo/bin/rustup show
-
-# This builds the binary.
-RUN $HOME/.cargo/bin/cargo build --locked --release
-
-# Create output folder
-RUN mkdir -p output
-
-VOLUME ["/output"]
-CMD cp ./target/release/avail-node /output
+WORKDIR /workdir
+COPY rust-toolchain.toml .
+RUN rustup show

--- a/scripts/binaries/x86_64/debian-13.Dockerfile
+++ b/scripts/binaries/x86_64/debian-13.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:13-slim
 
 RUN apt update -y && \
     apt install --fix-missing build-essential git clang curl libssl-dev llvm libudev-dev make cmake protobuf-compiler -y

--- a/scripts/binaries/x86_64/fedora-42.Dockerfile
+++ b/scripts/binaries/x86_64/fedora-42.Dockerfile
@@ -1,23 +1,11 @@
-FROM fedora:42 AS builder
+FROM fedora:42
 
-# This installs all dependencies that we need (besides Rust).
 RUN dnf update -y && \
     dnf install git clang curl make cmake protobuf-compiler -y
 
-# This installs Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && chmod u+x rust_install.sh && ./rust_install.sh -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
 
-ADD . ./workdir
-WORKDIR "/workdir"
-
-# This installs the right toolchain
-RUN $HOME/.cargo/bin/rustup show
-
-# This builds the binary.
-RUN $HOME/.cargo/bin/cargo build --locked --release
-
-# Create output folder
-RUN mkdir -p output
-
-VOLUME ["/output"]
-CMD cp ./target/release/avail-node /output
+WORKDIR /workdir
+COPY rust-toolchain.toml .
+RUN rustup show

--- a/scripts/binaries/x86_64/shared.dockerignore
+++ b/scripts/binaries/x86_64/shared.dockerignore
@@ -1,17 +1,2 @@
-# Ignore everything
 *
-
-# Allow files and directories
-!/runtime
-!/rpc
-!/patricia-merkle-trie
-!/pallets
-!/node
-!/misc
-!/client
-!/base
-!Cargo.toml
-!Cargo.lock
 !rust-toolchain.toml
-!rustfmt.toml
-!.git

--- a/scripts/binaries/x86_64/ubuntu-2204.Dockerfile
+++ b/scripts/binaries/x86_64/ubuntu-2204.Dockerfile
@@ -1,23 +1,11 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:22.04
 
-# This installs all dependencies that we need (besides Rust).
 RUN apt update -y && \
     apt install --fix-missing build-essential git clang curl libssl-dev llvm libudev-dev make cmake protobuf-compiler -y
 
-# This installs Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && chmod u+x rust_install.sh && ./rust_install.sh -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
 
-ADD . ./workdir
-WORKDIR "/workdir"
-
-# This installs the right toolchain
-RUN $HOME/.cargo/bin/rustup show
-
-# This builds the binary.
-RUN $HOME/.cargo/bin/cargo build --locked --release
-
-# Create output folder
-RUN mkdir -p output
-
-VOLUME ["/output"]
-CMD cp ./target/release/avail-node /output
+WORKDIR /workdir
+COPY rust-toolchain.toml .
+RUN rustup show

--- a/scripts/binaries/x86_64/ubuntu-2404.Dockerfile
+++ b/scripts/binaries/x86_64/ubuntu-2404.Dockerfile
@@ -1,23 +1,11 @@
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:24.04
 
-# This installs all dependencies that we need (besides Rust).
 RUN apt update -y && \
     apt install --fix-missing build-essential git clang curl libssl-dev llvm libudev-dev make cmake protobuf-compiler -y
 
-# This installs Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && chmod u+x rust_install.sh && ./rust_install.sh -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
 
-ADD . ./workdir
-WORKDIR "/workdir"
-
-# This installs the right toolchain
-RUN $HOME/.cargo/bin/rustup show
-
-# This builds the binary.
-RUN $HOME/.cargo/bin/cargo build --locked --release
-
-# Create output folder
-RUN mkdir -p output
-
-VOLUME ["/output"]
-CMD cp ./target/release/avail-node /output
+WORKDIR /workdir
+COPY rust-toolchain.toml .
+RUN rustup show


### PR DESCRIPTION
## What

- **wasm first**: a dedicated `wasm` job builds only `da-runtime` and publishes `da_runtime.compact.compressed.wasm` before any binary job starts.
- **Incremental builds on the self-hosted runner**: `scripts/binaries/build.sh` now builds a toolchain-only image per distro and runs `cargo build` inside `podman run` with the checkout bind-mounted and named volumes for the cargo registry and `target/` (`avail-cargo-registry`, `avail-target-<distro>`).
- **Targets**: x86_64 matrix is `ubuntu-2204`, `ubuntu-2404`, `debian-12`, `debian-13`; arm64 job unchanged. `fedora-42` / `arch` Dockerfiles remain for local use but are out of CI.
- **Signing/upload** deduplicated into `.github/actions/sign-and-publish` (asset + `.sha256` + `.sig` + `.sha256.sig`, uploaded via `file_glob`).
- Removed the per-job `apt install podman` step (self-hosted and GitHub runners already have podman).

## Verified on the sp1-builder runner

| Build | Result | Time |
|---|---|---|
| debian-13, `CARGO_ARGS="-p da-runtime"` (wasm) | ok | 6m20s cold (incl. image build) |
| ubuntu-2204, `ZIP=1` (binary + tarball) | ok, `avail-node --version` = `2.3.4-a4bdfe2609f` | 7m42s cold |
| ubuntu-2204 re-run (warm volumes) | ok | 1m11s |

## Notes

- The runner processes one job at a time, so the x86_64 matrix is still serial; the cache volumes are what make it fast after the first tag.
- First release after merge is cold for every distro (~8 min each).
- `releaser_docker.yml` untouched.