### PR TITLE
ci(docker): build release image from the checkout instead of cloning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,4 @@
 target
-.git
-.github
-.maintain
-misc
-tests
+output
 ts-interfaces
+node_modules

--- a/.github/workflows/releaser_docker.yml
+++ b/.github/workflows/releaser_docker.yml
@@ -43,5 +43,3 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: availj/avail:${{ steps.prepare.outputs.tag_name }}
-          build-args: |
-            AVAIL_TAG=${{ steps.prepare.outputs.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ RUN apt update -y && \
 
 WORKDIR "/da/src"
 
-# Clone repo
-ARG AVAIL_TAG=v2.3.4.0
-RUN git clone -b $AVAIL_TAG --single-branch https://github.com/availproject/avail.git .
+COPY . .
 
 # This installs Rust and updates Rust to the right version.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && chmod u+x rust_install.sh && ./rust_install.sh -y


### PR DESCRIPTION
## Why

`Releaser Docker` for `v2.4.0.0` failed at the `git clone` step inside the root `Dockerfile`:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

GitHub is throttling anonymous git-over-HTTPS from the self-hosted runner's IP (reproduced from both the host and a container on the VM; plain HTTPS returns 200, the git handshake fails). The runner's own `actions/checkout` is unaffected because it uses a token.

## What

- `Dockerfile`: `COPY . .` the checked-out source instead of cloning the tag. This also removes the requirement that the tag already exists on GitHub before the image builds.
- `.dockerignore`: previously excluded `misc/` and `.git`, which was harmless while the Dockerfile cloned, but with `COPY` they are needed (embedded chain specs via `include_bytes!`, and the git hash in `avail-node --version`). Now excludes only build outputs.
- `releaser_docker.yml`: drop the unused `AVAIL_TAG` build-arg.

## Publishing v2.4.0.0

Re-running the failed run reuses the workflow/Dockerfile from the tag commit, so it will fail again. After merge, either tag a new patch release or build and push `availj/avail:v2.4.0.0` manually from the tag with the fixed Dockerfile.