### PR TITLE
ci(docker): allow dispatching the image build for an existing tag

### DIFF
--- a/.github/workflows/releaser_docker.yml
+++ b/.github/workflows/releaser_docker.yml
@@ -6,6 +6,13 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build the image for
+        required: true
+
+env:
+  TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   # build avail image and publish to dockerhub
@@ -15,18 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      - name: Use tag source with current Dockerfile
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch --depth 1 origin "refs/tags/$TAG:refs/tags/$TAG"
+          git checkout --detach "$TAG"
+          git checkout "$GITHUB_SHA" -- Dockerfile .dockerignore
 
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Prepare
-        id: prepare
-        run: |
-            TAG=${GITHUB_REF#refs/tags/}
-            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -42,4 +47,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: availj/avail:${{ steps.prepare.outputs.tag_name }}
+          tags: availj/avail:${{ env.TAG }}


### PR DESCRIPTION
## Why

The v2.4.0.0 `Releaser Docker` run failed before #850 landed, and re-running it reuses the Dockerfile from the tag commit. This adds a way to publish the image for an existing tag using the fixed Dockerfile.

## What

- `workflow_dispatch` now takes a required `tag` input.
- On dispatch the job checks out that tag (HEAD at the tag, so `avail-node --version` reports the tag's hash) and overlays `Dockerfile` and `.dockerignore` from the commit the workflow was dispatched on.
- Image tag comes from `inputs.tag`, or `github.ref_name` on tag pushes (unchanged behaviour).
- Removes the QEMU step: the build is amd64-only on an amd64 runner.

## Usage

```
gh workflow run releaser_docker.yml -R availproject/avail --ref main -f tag=v2.4.0.0
```